### PR TITLE
newline is in std.ascii

### DIFF
--- a/build.d
+++ b/build.d
@@ -11,6 +11,7 @@ import std.path;
 import std.process;
 import std.stdio;
 import std.string;
+import std.ascii : newline;
 
 //////////////////////////////////////////////////////////////////////////
 // Helpers


### PR DESCRIPTION
presumably it was somewhere else until quite recently. Added the correct import, build.d now works with dmd git master.
