### PR TITLE
Succeeded to build on Linux Mint 17.1(64-bit).

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,6 +48,15 @@ available in the system package manager.
 * libgtk2.0-dev
 * libgnomeui-dev
 
+If you are using a 64-bit OS, please add `:i386` after the name of the package.
+And need the `gcc-multilib` package.
+
+For example:
+
+		$ sudo apt-get install libcairo2-dev:i386
+		    :
+		$ sudo apt-get install gcc-multilib
+
 #### For D1
 
 * [Tango](http://dsource.org/projects/tango)

--- a/build.d
+++ b/build.d
@@ -103,7 +103,7 @@ static if (isWindows) {
                                   "Xext", "Xrender", "Xinerama", "Xi", "Xrandr", "Xcursor",
                                   "Xcomposite", "Xdamage", "X11", "Xfixes", "pango-1.0",
                                   "gobject-2.0", "gmodule-2.0", "dl", "glib-2.0", "cairo",
-                                  "gnomeui-2" ];
+                                  "gnomeui-2", "gnomevfs-2" ];
     immutable LIBNAMES_BASIC  = [ "dwt-base" ];
 }
 
@@ -324,7 +324,7 @@ void buildApp( string basedir, string srcdir, string resdir, in string[] dflags,
         rsp ~= "-L-L" ~ win_path(DIR_LIB);
         foreach_reverse (libname; libnames) {
             auto absname = .buildPath( DIR_LIB, libname ~ LIBEXT );
-            rsp ~= absname;
+            rsp ~= "-L" ~ absname;
         }
         foreach_reverse (soname; SONAMES_BASIC) {
             rsp ~= "-L-l" ~ soname;


### PR DESCRIPTION
In the current procedure in `README.markdown` will fail to build on Linux Mint 17.1(64bit).
Accordingly, I added the procedure to README.

And since link errors has occurred, I fixed `build.d`.