### PR TITLE
linux 64.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -48,15 +48,6 @@ available in the system package manager.
 * libgtk2.0-dev
 * libgnomeui-dev
 
-If you are using a 64-bit OS, please add `:i386` after the name of the package.
-And need the `gcc-multilib` package.
-
-For example:
-
-		$ sudo apt-get install libcairo2-dev:i386
-		    :
-		$ sudo apt-get install gcc-multilib
-
 #### For D1
 
 * [Tango](http://dsource.org/projects/tango)

--- a/build.d
+++ b/build.d
@@ -210,7 +210,11 @@ void buildTree( string basedir, string srcdir, string resdir, string[] dcargs=nu
     }
     rsp ~= "-c";
     rsp ~= "-op";
-    rsp ~= "-m32";
+    version (linux) {
+        // DWT2-GTK is 64 bit supported.
+    } else {
+        rsp ~= "-m32";
+    }
     if (isDebug) {
         rsp ~= "-debug";
         rsp ~= "-g";
@@ -295,7 +299,11 @@ void buildApp( string basedir, string srcdir, string resdir, in string[] dflags,
     rsp ~= "-I" ~ win_path(DIR_IMP);
     rsp ~= "-J" ~ win_path(resdir_abs);
     rsp ~= "-J" ~ win_path(DIR_RES);
-    rsp ~= "-m32";
+    version (linux) {
+        // DWT2-GTK is 64 bit supported.
+    } else {
+        rsp ~= "-m32";
+    }
     if (isDebug) {
         rsp ~= "-debug";
         rsp ~= "-g";


### PR DESCRIPTION
I was verified building and running of all snippets on linux 64-bit (Linux Mint 17.1 64-bit, excluding i386 library, and mint 17.1 32-bit).