### PR TITLE
Workaround: https://issues.dlang.org/show_bug.cgi?id=19758

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/image/JPEGDecoder.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/image/JPEGDecoder.d
@@ -6048,7 +6048,11 @@ static void jpeg_make_d_derived_tbl (jpeg_decompress_struct cinfo, bool isDC, in
 
     p = 0;
     for (l = 1; l <= 16; l++) {
-        if ((htbl.bits[l] & 0xFF) !is 0) {
+        // BUG: This variable is needed to avoid the following problem:
+        //      https://issues.dlang.org/show_bug.cgi?id=19758
+        auto htbl_bits_l = htbl.bits[l];
+        //if ((htbl.bits[l] & 0xFF) !is 0) {
+        if ((htbl_bits_l & 0xFF) !is 0) {
             /* valoffset[l] = huffval[] index of 1st symbol of code length l,
              * minus the minimum code of length l
              */


### PR DESCRIPTION
https://issues.dlang.org/show_bug.cgi?id=19758
This problem occurs in the DWT's JPEG decoder. As a result, a JPEG image is broken on Windows 64-bit.
If assign a value of htbl.bits into a variable, We can avoid generating wrong code.
This is a problem to be solved by the dmd fix. I can't tell if this code should be merged.