### PR TITLE
Fixes for dmd 2.087.0.

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleClientSite.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleClientSite.d
@@ -465,7 +465,7 @@ protected void addObjectReferences() {
         objIOleLink.Release();
     }
 }
-protected int AddRef() {
+package int AddRef() {
     refCount++;
     return refCount;
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleClientSite.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleClientSite.d
@@ -465,7 +465,7 @@ protected void addObjectReferences() {
         objIOleLink.Release();
     }
 }
-package int AddRef() {
+protected int AddRef() {
     refCount++;
     return refCount;
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleControlSite.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleControlSite.d
@@ -86,8 +86,9 @@ public class OleControlSite : OleClientSite
     // work around for IE destroying the caret
     static int SWT_RESTORECARET;
 
-    alias OleClientSite.AddRef AddRef;
-
+    override protected int AddRef() {
+        return super.AddRef();
+    }
 /**
  * Create an OleControlSite child widget using style bits
  * to select a particular look or set of properties.


### PR DESCRIPTION
A compilation error:

    org.eclipse.swt.win32.win32.x86\src\org\eclipse\swt\ole\win32\OleControlSite.d(886,43): Error: class `org.eclipse.swt.ole.win32.OleControlSite.OleControlSite` member AddRef is not accessible
    org.eclipse.swt.win32.win32.x86\src\org\eclipse\swt\ole\win32\OleControlSite.d(906,43): Error: class `org.eclipse.swt.ole.win32.OleControlSite.OleControlSite` member AddRef is not accessible
