### PR TITLE
Close a handles even if an exception occurs.

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Synchronizer.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Synchronizer.d
@@ -133,6 +133,13 @@ bool runAsyncMessages (bool all) {
         RunnableLock lock = removeFirst ();
         if (lock is null) return run;
         run = true;
+        scope (exit) {
+            if (!lock.syncExec) {
+                // Release handle of lock#cond.
+                // If not released here, the handle will not be released until the next GC works.
+                destroy(lock);
+            }
+        }
         synchronized (lock) {
             syncThread = lock.thread;
             try {
@@ -144,11 +151,6 @@ bool runAsyncMessages (bool all) {
                 syncThread = null;
                 lock.notifyAll ();
             }
-        }
-        if (!lock.syncExec) {
-            // Release handle of lock#cond.
-            // If not released here, the handle will not be released until the next GC works.
-            destroy(lock);
         }
     } while (all);
     return run;
@@ -189,6 +191,11 @@ public void syncExec (Runnable runnable) {
         if (runnable !is null) runnable.run ();
         return;
     }
+    scope (exit) {
+        // Release handle of lock#cond.
+        // If not released here, the handle will not be released until the next GC works.
+        destroy(lock);
+    }
     synchronized (lock) {
         bool interrupted = false;
         while (!lock.done ()) {
@@ -205,9 +212,6 @@ public void syncExec (Runnable runnable) {
             SWT.error (SWT.ERROR_FAILED_EXEC, lock.throwable);
         }
     }
-    // Release handle of lock#cond.
-    // If not released here, the handle will not be released until the next GC works.
-    destroy(lock);
 }
 
 }


### PR DESCRIPTION
See Also: issue #49, pull request #50
A semaphore handles was not closed when a exception occurred.
Use a scope guard statement to ensure that handles is closed.