### PR TITLE
Remove function overloads in extern(Windows)

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/Accessible.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/Accessible.d
@@ -1018,7 +1018,7 @@ public class Accessible {
                 } else {
                     tvItem.hItem = cast(HTREEITEM) v.lVal;
                 }
-                auto result = OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+                auto result = OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                 bool checked = (result !is 0) && (((tvItem.state >> 12) & 1) is 0);
                 if (checked) event.detail |= ACC.STATE_CHECKED;
                 grayed = tvItem.state >> 12 > 2;

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/DragSource.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/DragSource.d
@@ -698,7 +698,7 @@ HRESULT SetData(FORMATETC* pFormatetc, STGMEDIUM* pmedium, int fRelease) {
         int[1] ptrEffect;
         OS.MoveMemory(ptrEffect.ptr, stgmedium.unionField,4);
         int[1] effect;
-        OS.MoveMemory(effect.ptr, ptrEffect[0],4);
+        OS.MoveMemory(effect.ptr, cast(LPCVOID)ptrEffect[0],4);
         dataEffect = osToOp(effect[0]);
     }
     if (fRelease is 1) {

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TableDragSourceEffect.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TableDragSourceEffect.d
@@ -95,7 +95,7 @@ public class TableDragSourceEffect : DragSourceEffect {
         if (!OS.IsWinCE && OS.WIN32_VERSION >= OS.VERSION (5, 1)) {
             SHDRAGIMAGE shdi;
             int DI_GETDRAGIMAGE = OS.RegisterWindowMessage ( "ShellGetDragImage"w.ptr ); //$NON-NLS-1$
-            if (OS.SendMessage (control.handle, DI_GETDRAGIMAGE, 0, &shdi) !is 0) {
+            if (OS.SendMessage (control.handle, DI_GETDRAGIMAGE, 0, cast(LPARAM)&shdi) !is 0) {
                 if ((control.getStyle() & SWT.MIRRORED) !is 0) {
                     event.x += shdi.sizeDragImage.cx - shdi.ptOffset.x;
                 } else {
@@ -196,7 +196,7 @@ public class TableDragSourceEffect : DragSourceEffect {
                 TableItem selected = selection[i];
                 Rectangle cell = selected.getBounds(0);
                 POINT pt;
-                HANDLE imageList = cast(HANDLE) OS.SendMessage (table.handle, OS.LVM_CREATEDRAGIMAGE, table.indexOf(selected), &pt);
+                HANDLE imageList = cast(HANDLE) OS.SendMessage (table.handle, OS.LVM_CREATEDRAGIMAGE, table.indexOf(selected), cast(LPARAM)&pt);
                 OS.ImageList_Draw(imageList, 0, hDC1, cell.x - bounds.x, cell.y - bounds.y, OS.ILD_SELECTED);
                 OS.ImageList_Destroy(imageList);
             }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TableDropTargetEffect.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TableDropTargetEffect.d
@@ -119,7 +119,7 @@ public class TableDropTargetEffect : DropTargetEffect {
         if (dropHighlight !is null) {
             LVITEM lvItem;
             lvItem.stateMask = OS.LVIS_DROPHILITED;
-            OS.SendMessage(handle, OS.LVM_SETITEMSTATE, -1, &lvItem);
+            OS.SendMessage(handle, OS.LVM_SETITEMSTATE, -1, cast(LPARAM)&lvItem);
             dropHighlight = null;
         }
         scrollBeginTime = 0;
@@ -153,7 +153,7 @@ public class TableDropTargetEffect : DropTargetEffect {
         LVHITTESTINFO pinfo;
         pinfo.pt.x = coordinates.x;
         pinfo.pt.y = coordinates.y;
-        OS.SendMessage(handle, OS.LVM_HITTEST, 0, &pinfo);
+        OS.SendMessage(handle, OS.LVM_HITTEST, 0, cast(LPARAM)&pinfo);
         if ((effect & DND.FEEDBACK_SCROLL) is 0) {
             scrollBeginTime = 0;
             scrollIndex = -1;
@@ -169,7 +169,7 @@ public class TableDropTargetEffect : DropTargetEffect {
                     } else {
                         RECT itemRect;
                         itemRect.left = OS.LVIR_BOUNDS;
-                        if (OS.SendMessage (handle, OS.LVM_GETITEMRECT, pinfo.iItem, &itemRect) !is 0) {
+                        if (OS.SendMessage (handle, OS.LVM_GETITEMRECT, pinfo.iItem, cast(LPARAM)&itemRect) !is 0) {
                             RECT rect;
                             OS.GetClientRect (handle, &rect);
                             POINT pt;
@@ -199,16 +199,16 @@ public class TableDropTargetEffect : DropTargetEffect {
             if (dropHighlight !is item) {
                 LVITEM lvItem;
                 lvItem.stateMask = OS.LVIS_DROPHILITED;
-                OS.SendMessage(handle, OS.LVM_SETITEMSTATE, -1, &lvItem);
+                OS.SendMessage(handle, OS.LVM_SETITEMSTATE, -1, cast(LPARAM)&lvItem);
                 lvItem.state = OS.LVIS_DROPHILITED;
-                OS.SendMessage(handle, OS.LVM_SETITEMSTATE, pinfo.iItem, &lvItem);
+                OS.SendMessage(handle, OS.LVM_SETITEMSTATE, pinfo.iItem, cast(LPARAM)&lvItem);
                 dropHighlight = item;
             }
         } else {
             if (dropHighlight !is null) {
                 LVITEM lvItem;
                 lvItem.stateMask = OS.LVIS_DROPHILITED;
-                OS.SendMessage(handle, OS.LVM_SETITEMSTATE, -1, &lvItem);
+                OS.SendMessage(handle, OS.LVM_SETITEMSTATE, -1, cast(LPARAM)&lvItem);
                 dropHighlight = null;
             }
         }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TreeDragSourceEffect.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TreeDragSourceEffect.d
@@ -94,7 +94,7 @@ public class TreeDragSourceEffect : DragSourceEffect {
         if (!OS.IsWinCE && OS.WIN32_VERSION >= OS.VERSION (5, 1)) {
             SHDRAGIMAGE shdi;
             int DI_GETDRAGIMAGE = OS.RegisterWindowMessage ("ShellGetDragImage"w.ptr); //$NON-NLS-1$
-            if (OS.SendMessage (control.handle, DI_GETDRAGIMAGE, 0, &shdi) !is 0) {
+            if (OS.SendMessage (control.handle, DI_GETDRAGIMAGE, 0, cast(LPARAM)&shdi) !is 0) {
                 if ((control.getStyle() & SWT.MIRRORED) !is 0) {
                     event.x += shdi.sizeDragImage.cx - shdi.ptOffset.x;
                 } else {
@@ -188,7 +188,7 @@ public class TreeDragSourceEffect : DragSourceEffect {
             for (int i = 0; i < count; i++) {
                 TreeItem selected = selection[i];
                 Rectangle cell = selected.getBounds(0);
-                HANDLE imageList = cast(HANDLE) OS.SendMessage(tree.handle, OS.TVM_CREATEDRAGIMAGE, 0, selected.handle);
+                HANDLE imageList = cast(HANDLE) OS.SendMessage(tree.handle, OS.TVM_CREATEDRAGIMAGE, 0, cast(LPARAM)selected.handle);
                 OS.ImageList_Draw(imageList, 0, hDC1, cell.x - bounds.x, cell.y - bounds.y, OS.ILD_SELECTED);
                 OS.ImageList_Destroy(imageList);
             }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TreeDropTargetEffect.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/dnd/TreeDropTargetEffect.d
@@ -135,7 +135,7 @@ public class TreeDropTargetEffect : DropTargetEffect {
             tvItem.mask = OS.TVIF_STATE;
             tvItem.stateMask = OS.TVIS_DROPHILITED;
             tvItem.state = 0;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             dropIndex = -1;
         }
         if (insertItem !is null) {
@@ -176,7 +176,7 @@ public class TreeDropTargetEffect : DropTargetEffect {
         TVHITTESTINFO lpht;
         lpht.pt.x = coordinates.x;
         lpht.pt.y = coordinates.y;
-        OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+        OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
         auto hItem = cast(ptrdiff_t)lpht.hItem;
         if ((effect & DND.FEEDBACK_SCROLL) is 0) {
             scrollBeginTime = 0;
@@ -204,7 +204,7 @@ public class TreeDropTargetEffect : DropTargetEffect {
                         }
                     }
                     if (scroll) {
-                        OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, nextItem);
+                        OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, cast(LPARAM)nextItem);
                         tree.redraw();
                     }
                     scrollBeginTime = 0;
@@ -245,7 +245,7 @@ public class TreeDropTargetEffect : DropTargetEffect {
             tvItem.mask = OS.TVIF_STATE;
             tvItem.stateMask = OS.TVIS_DROPHILITED;
             tvItem.state = 0;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             dropIndex = -1;
         }
         if (hItem !is -1 && hItem !is dropIndex && (effect & DND.FEEDBACK_SELECT) !is 0) {
@@ -254,7 +254,7 @@ public class TreeDropTargetEffect : DropTargetEffect {
             tvItem.mask = OS.TVIF_STATE;
             tvItem.stateMask = OS.TVIS_DROPHILITED;
             tvItem.state = OS.TVIS_DROPHILITED;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             dropIndex = hItem;
         }
         if ((effect & DND.FEEDBACK_INSERT_BEFORE) !is 0 || (effect & DND.FEEDBACK_INSERT_AFTER) !is 0) {

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/win32/OS.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/win32/OS.d
@@ -3593,7 +3593,7 @@ public static WPARAM MAKEWPARAM(int l, int h){
 	return cast(WPARAM)MAKELONG( l, h );
 }
 public static LPARAM MAKELPARAM(int l, int h){
-	return cast(LPARAM)MAKELONG( l, h );
+    return cast(LPARAM)MAKELONG( l, h );
 }
 public static LRESULT MAKELRESULT(int l, int h){
 	return cast(LRESULT)MAKELONG( l, h );
@@ -3612,7 +3612,7 @@ public static int GET_Y_LPARAM(LPARAM lp){
 
 static bool TreeView_GetItemRect( HWND hwnd, HTREEITEM hitem, RECT* prc, bool code) {
     *cast(HTREEITEM *)prc = hitem;
-    return cast(bool) SendMessage( hwnd, TVM_GETITEMRECT, code, prc );
+    return cast(bool) SendMessage( hwnd, TVM_GETITEMRECT, code, cast(LPARAM)prc );
 }
 static size_t strlen( PCHAR ptr ){
     version(Tango){

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/win32/WINAPI.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/win32/WINAPI.d
@@ -1899,9 +1899,6 @@ version(Tango){
             LONG DispatchMessageA(LPMSG);
             WINBOOL PeekMessageA(LPMSG, HWND, UINT, UINT, UINT);
             LRESULT SendMessageA(HWND, UINT, WPARAM, LPARAM);
-            LRESULT SendMessageA(HWND, UINT, void*, LPARAM);
-            LRESULT SendMessageA(HWND, UINT, WPARAM, void*);
-            LRESULT SendMessageA(HWND, UINT, void*, void*);
             LRESULT SendMessageTimeoutA(HWND, UINT, WPARAM, LPARAM, UINT, UINT, PDWORD_PTR);
             WINBOOL SendNotifyMessageA(HWND, UINT, WPARAM, LPARAM);
             WINBOOL SendMessageCallbackA(HWND, UINT, WPARAM, LPARAM, SENDASYNCPROC, ULONG_PTR);
@@ -2299,9 +2296,6 @@ version(Tango){
             LONG DispatchMessageW(LPMSG);
             WINBOOL PeekMessageW(LPMSG, HWND, UINT, UINT, UINT);
             LRESULT SendMessageW(HWND, UINT, WPARAM, LPARAM);
-            LRESULT SendMessageW(HWND, UINT, WPARAM, void*);
-            LRESULT SendMessageW(HWND, UINT, void*, LPARAM);
-            LRESULT SendMessageW(HWND, UINT, void*, void*);
             LRESULT SendMessageTimeoutW(HWND, UINT, WPARAM, LPARAM, UINT, UINT, PDWORD_PTR);
             WINBOOL SendNotifyMessageW(HWND, UINT, WPARAM, LPARAM);
             WINBOOL SendMessageCallbackW(HWND, UINT, WPARAM, LPARAM, SENDASYNCPROC, ULONG_PTR);
@@ -5149,12 +5143,7 @@ void OleUninitialize();
 //);
 //alias STDWIN.RoundRect RoundRect;
 
-// basic
 void RtlMoveMemory(void* Destination, LPCVOID Source, SIZE_T Length);
-// extends
-void RtlMoveMemory(intptr_t Destination, LPCVOID Source, SIZE_T Length);
-void RtlMoveMemory(void* Destination, intptr_t Source, SIZE_T Length);
-void RtlMoveMemory(intptr_t Destination, intptr_t Source, SIZE_T Length);
 
 LPITEMIDLIST SHBrowseForFolderA(
     BROWSEINFOA* lpbi

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleAutomation.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleAutomation.d
@@ -270,7 +270,7 @@ public OleFunctionDescription getFunctionDescription(int index) {
             int[1] pTypedesc;
             COM.MoveMemory(pTypedesc.ptr, (cast(void*)funcdesc.lprgelemdescParam) + i * 16, 4);
             short[1] vt2;
-            COM.MoveMemory(vt2.ptr, pTypedesc[0] + 4, 2);
+            COM.MoveMemory(vt2.ptr, cast(LPCVOID)(pTypedesc[0] + 4), 2);
             vt[0] = cast(short)(vt2[0] | COM.VT_BYREF);
         }
         data.args[i].type = vt[0];

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleFrame.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/ole/win32/OleFrame.d
@@ -216,7 +216,7 @@ static extern(Windows) .LRESULT getMsgProc(int code, WPARAM wParam, LPARAM lPara
         return OS.CallNextHookEx(hHook.value, code, wParam, lParam);
     }
     MSG* msg = cast(MSG*)(cast(ValueWrapperT!(MSG*))display.getData(HHOOKMSG)).value;
-    OS.MoveMemory(msg, lParam, MSG.sizeof);
+    OS.MoveMemory(msg, cast(LPCVOID)lParam, MSG.sizeof);
     int message = msg.message;
     if (OS.WM_KEYFIRST <= message && message <= OS.WM_KEYLAST) {
         if (display !is null) {
@@ -323,7 +323,7 @@ static extern(Windows) .LRESULT getMsgProc(int code, WPARAM wParam, LPARAM lPara
                         // by the application, zero out message, wParam and lParam
                         msg.message = OS.WM_NULL;
                         msg.wParam = msg.lParam = 0;
-                        OS.MoveMemory(lParam, msg, MSG.sizeof);
+                        OS.MoveMemory(cast(LPVOID)lParam, msg, MSG.sizeof);
                         return 0;
                     }
                 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Button.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Button.d
@@ -179,7 +179,7 @@ void _setImage (Image image) {
                 OS.SetWindowLong (handle, OS.GWL_STYLE, newBits);
                 OS.InvalidateRect (handle, null, true);
             }
-            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, &buttonImageList);
+            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
         } else {
             OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, 0);
         }
@@ -282,7 +282,7 @@ void _setImage (Image image) {
         newBits &= ~(OS.BS_BITMAP | OS.BS_ICON);
         newBits |= imageBits;
         if (newBits !is oldBits) OS.SetWindowLong (handle, OS.GWL_STYLE, newBits);
-        OS.SendMessage (handle, OS.BM_SETIMAGE, fImageType, hImage);
+        OS.SendMessage (handle, OS.BM_SETIMAGE, fImageType, cast(LPARAM)hImage);
     }
 }
 
@@ -307,7 +307,7 @@ void _setText (String text) {
                 newBits &= ~(OS.BS_CENTER | OS.BS_RIGHT);
                 newBits |= OS.BS_LEFT;
             }
-            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, &buttonImageList);
+            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
         }
     } else {
         newBits &= ~(OS.BS_BITMAP | OS.BS_ICON);
@@ -434,18 +434,18 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
             SIZE size;
             if (wHint !is SWT.DEFAULT) {
                 size.cx = wHint;
-                OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, &size);
+                OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, cast(LPARAM)&size);
                 width = size.cx;
                 height = size.cy;
             } else {
-                OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, &size);
+                OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, cast(LPARAM)&size);
                 width = size.cy;
                 height = size.cy;
                 size.cy = 0;
                 while (size.cy !is height) {
                     size.cx = width++;
                     size.cy = 0;
-                    OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, &size);
+                    OS.SendMessage (handle, OS.BCM_GETIDEALSIZE, 0, cast(LPARAM)&size);
                 }
             }
         } else {
@@ -614,7 +614,7 @@ override void enableWidget (bool enabled) {
     if (OS.COMCTL32_MAJOR >= 6) {
         if (imageList !is null) {
             BUTTON_IMAGELIST buttonImageList;
-            OS.SendMessage (handle, OS.BCM_GETIMAGELIST, 0, &buttonImageList);
+            OS.SendMessage (handle, OS.BCM_GETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
             if (imageList !is null) imageList.dispose ();
             imageList = new ImageList (style & SWT.RIGHT_TO_LEFT);
             if (OS.IsWindowEnabled (handle)) {
@@ -625,7 +625,7 @@ override void enableWidget (bool enabled) {
                 imageList.add (disabledImage);
             }
             buttonImageList.himl = imageList.getHandle ();
-            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, &buttonImageList);
+            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
             /*
             * Bug in Windows.  Under certain cirumstances yet to be
             * isolated, BCM_SETIMAGELIST does not redraw the control
@@ -808,7 +808,7 @@ void printWidget (HWND hwnd, GC gc) {
     auto hDC = gc.handle;
     if (!OS.PrintWindow (hwnd, hDC, 0)) {
         int flags = OS.PRF_CLIENT | OS.PRF_NONCLIENT | OS.PRF_ERASEBKGND | OS.PRF_CHILDREN;
-        OS.SendMessage (hwnd, OS.WM_PRINT, hDC, flags);
+        OS.SendMessage (hwnd, OS.WM_PRINT, cast(WPARAM)hDC, flags);
     }
 }
 
@@ -922,7 +922,7 @@ public void setAlignment (int alignment) {
                 newBits &= ~(OS.BS_CENTER | OS.BS_RIGHT);
                 newBits |= OS.BS_LEFT;
             }
-            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, &buttonImageList);
+            OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
         }
     }
     if (newBits !is oldBits) {
@@ -937,7 +937,7 @@ void setDefault (bool value) {
     int bits = OS.GetWindowLong (handle, OS.GWL_STYLE);
     if (value) {
         bits |= OS.BS_DEFPUSHBUTTON;
-        OS.SendMessage (hwndShell, OS.DM_SETDEFID, handle, 0);
+        OS.SendMessage (hwndShell, OS.DM_SETDEFID, cast(WPARAM)handle, 0);
     } else {
         bits &= ~OS.BS_DEFPUSHBUTTON;
         OS.SendMessage (hwndShell, OS.DM_SETDEFID, 0, 0);
@@ -1039,7 +1039,7 @@ public void setGrayed (bool grayed) {
     this.message = message;
     if (OS.COMCTL32_VERSION >= OS.VERSION (6, 1)) {
         if ((style & SWT.COMMAND) !is 0) {
-            OS.SendMessage (handle, OS.BCM_SETNOTE, 0, cast(void*)StrToTCHARz( message ));
+            OS.SendMessage (handle, OS.BCM_SETNOTE, 0, cast(LPARAM)StrToTCHARz( message ));
         }
     }
 }
@@ -1271,11 +1271,11 @@ override LRESULT WM_SIZE (WPARAM wParam, LPARAM lParam) {
         if ((style & (SWT.PUSH | SWT.TOGGLE)) !is 0) {
             if (imageList !is null && text.length !is 0) {
                 BUTTON_IMAGELIST buttonImageList;
-                OS.SendMessage (handle, OS.BCM_GETIMAGELIST, 0, &buttonImageList);
+                OS.SendMessage (handle, OS.BCM_GETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
                 buttonImageList.uAlign = OS.BUTTON_IMAGELIST_ALIGN_LEFT;
                 buttonImageList.margin.left = computeLeftMargin ();
                 buttonImageList.margin.right = MARGIN;
-                OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, &buttonImageList);
+                OS.SendMessage (handle, OS.BCM_SETIMAGELIST, 0, cast(LPARAM)&buttonImageList);
             }
         }
     }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Combo.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Combo.d
@@ -189,7 +189,7 @@ public void add (String string) {
     // SWT extension: allow null string
     //if (string is null) error (SWT.ERROR_NULL_ARGUMENT);
     auto buffer = StrToTCHARs( getCodePage(), string, true );
-    auto result = OS.SendMessage (handle, OS.CB_ADDSTRING, 0, cast(void*)buffer.ptr );
+    auto result = OS.SendMessage (handle, OS.CB_ADDSTRING, 0, cast(LPARAM)buffer.ptr );
     if (result is OS.CB_ERR) error (SWT.ERROR_ITEM_NOT_ADDED);
     if (result is OS.CB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
     if ((style & SWT.H_SCROLL) !is 0) setScrollWidth (buffer, true);
@@ -226,7 +226,7 @@ public void add (String string, int index) {
         error (SWT.ERROR_INVALID_RANGE);
     }
     auto buffer = StrToTCHARs( getCodePage(), string, true );
-    auto result = OS.SendMessage (handle, OS.CB_INSERTSTRING, index, cast(void*)buffer.ptr);
+    auto result = OS.SendMessage (handle, OS.CB_INSERTSTRING, index, cast(LPARAM)buffer.ptr);
     if (result is OS.CB_ERRSPACE || result is OS.CB_ERR) {
         error (SWT.ERROR_ITEM_NOT_ADDED);
     }
@@ -446,7 +446,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
                 length_ = cast(int)/*64bit*/OS.SendMessage (handle, OS.CB_GETLBTEXTLEN, i, 0);
                 if (length_ !is OS.CB_ERR) {
                     if (length_ + 1 > buffer.length ) buffer = new TCHAR[ length_ + 1 ], buffer[] =0;
-                    auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, i, buffer.ptr);
+                    auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, i, cast(LPARAM)buffer.ptr);
                     if (result !is OS.CB_ERR) {
                         OS.DrawText (hDC, buffer.ptr, length_, &rect, flags);
                         width = Math.max (width, rect.right - rect.left);
@@ -647,7 +647,7 @@ override bool dragDetect (HWND hwnd, int x, int y, bool filter, bool [] detect, 
         auto hwndText = OS.GetDlgItem (handle, CBID_EDIT);
         if (hwndText !is null) {
             int start, end;
-            OS.SendMessage (handle, OS.CB_GETEDITSEL, &start, &end);
+            OS.SendMessage (handle, OS.CB_GETEDITSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             if (start !is end ) {
                 auto lParam = OS.MAKELPARAM (x, y);
                 int position = OS.LOWORD (OS.SendMessage (hwndText, OS.EM_CHARFROMPOS, 0, lParam));
@@ -685,7 +685,7 @@ public String getItem (int index) {
     auto length_ = OS.SendMessage (handle, OS.CB_GETLBTEXTLEN, index, 0);
     if (length_ !is OS.CB_ERR) {
         TCHAR[] buffer = new TCHAR[ length_ + 1];
-        auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, index, buffer.ptr);
+        auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, index, cast(LPARAM)buffer.ptr);
         if (result !is OS.CB_ERR) return TCHARzToStr( buffer.ptr );
     }
     auto count = OS.SendMessage (handle, OS.CB_GETCOUNT, 0, 0);
@@ -849,7 +849,7 @@ public Point getSelection () {
         return new Point (0, OS.GetWindowTextLength (handle));
     }
     int start, end;
-    OS.SendMessage (handle, OS.CB_GETEDITSEL, &start, &end);
+    OS.SendMessage (handle, OS.CB_GETEDITSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     if (!OS.IsUnicode && OS.IsDBLocale) {
         start = mbcsToWcsPos (start);
         end = mbcsToWcsPos (end);
@@ -1031,7 +1031,7 @@ public int indexOf (String string, int start) {
     int index = start - 1, last = 0;
     LPCTSTR buffer = StrToTCHARz( string );
     do {
-        index = cast(int)/*64bit*/OS.SendMessage (handle, OS.CB_FINDSTRINGEXACT, last = index, cast(void*)buffer);
+        index = cast(int)/*64bit*/OS.SendMessage (handle, OS.CB_FINDSTRINGEXACT, last = index, cast(LPARAM)buffer);
         if (index is OS.CB_ERR || index <= last) return -1;
     } while (string!=/*eq*/getItem (index));
     return index;
@@ -1108,7 +1108,7 @@ void remove (int index, bool notify) {
             error (SWT.ERROR_INVALID_RANGE);
         }
         buffer = new TCHAR[ length_ + 1];
-        auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, index, buffer.ptr);
+        auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, index, cast(LPARAM)buffer.ptr);
         if (result is OS.CB_ERR) {
             auto count = OS.SendMessage (handle, OS.CB_GETCOUNT, 0, 0);
             if (0 <= index && index < count) error (SWT.ERROR_ITEM_NOT_REMOVED);
@@ -1182,7 +1182,7 @@ public void remove (int start, int end) {
             auto length_ = OS.SendMessage (handle, OS.CB_GETLBTEXTLEN, start, 0);
             if (length_ is OS.CB_ERR) break;
             buffer = new TCHAR[ length_ + 1];
-            auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, start, buffer.ptr);
+            auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, start, cast(LPARAM)buffer.ptr);
             if (result is OS.CB_ERR) break;
         }
         auto result = OS.SendMessage (handle, OS.CB_DELETESTRING, start, 0);
@@ -1412,7 +1412,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
     if (newText is oldText) return true;
     LPCTSTR buffer = StrToTCHARz( newText );
     OS.SendMessage (hwndText, OS.EM_SETSEL, start, end);
-    OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+    OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
     return false;
 }
 
@@ -1493,7 +1493,7 @@ override void setBounds (int x, int y, int width, int height, int flags) {
         RECT rect;
         OS.GetWindowRect (handle, &rect);
         if (rect.right - rect.left !is 0) {
-            if (OS.SendMessage (handle, OS.CB_GETDROPPEDCONTROLRECT, 0, &rect) !is 0) {
+            if (OS.SendMessage (handle, OS.CB_GETDROPPEDCONTROLRECT, 0, cast(LPARAM)&rect) !is 0) {
                 int oldWidth = rect.right - rect.left, oldHeight = rect.bottom - rect.top;
                 if (oldWidth is width && oldHeight is height) flags |= OS.SWP_NOSIZE;
             }
@@ -1580,7 +1580,7 @@ public void setItems (String [] items) {
     for (int i=0; i<items.length; i++) {
         String string = items [i];
         LPCTSTR buffer = StrToTCHARz( string );
-        auto code = OS.SendMessage (handle, OS.CB_ADDSTRING, 0, cast(void*)buffer);
+        auto code = OS.SendMessage (handle, OS.CB_ADDSTRING, 0, cast(LPARAM)buffer);
         if (code is OS.CB_ERR) error (SWT.ERROR_ITEM_NOT_ADDED);
         if (code is OS.CB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
         if ((style & SWT.H_SCROLL) !is 0) {
@@ -1692,7 +1692,7 @@ void setScrollWidth () {
         auto length_ = OS.SendMessage (handle, OS.CB_GETLBTEXTLEN, i, 0);
         if (length_ !is OS.CB_ERR) {
             TCHAR[] buffer = new TCHAR [ length_ + 1];
-            auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, i, buffer.ptr);
+            auto result = OS.SendMessage (handle, OS.CB_GETLBTEXT, i, cast(LPARAM)buffer.ptr);
             if (result !is OS.CB_ERR) {
                 OS.DrawText (hDC, buffer.ptr, -1, &rect, flags);
                 newWidth = Math.max (newWidth, rect.right - rect.left);
@@ -2221,7 +2221,7 @@ override LRESULT WM_SIZE (WPARAM wParam, LPARAM lParam) {
             if (length_ !is 0) {
                 buffer = new TCHAR[ length_ + 1];
                 OS.GetWindowText (handle, buffer.ptr, length_ + 1);
-                OS.SendMessage (handle, OS.CB_GETEDITSEL, &start, &end);
+                OS.SendMessage (handle, OS.CB_GETEDITSEL, cast(WPARAM)&start, cast(LPARAM)&end);
                 redraw = drawCount is 0 && OS.IsWindowVisible (handle);
                 if (redraw) setRedraw (false);
             }
@@ -2344,14 +2344,14 @@ LRESULT wmClipboard (HWND hwndText, int msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
         case OS.WM_CLEAR:
         case OS.WM_CUT:
-            OS.SendMessage (hwndText, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             if (start  !is end ) {
                 newText = "";
                 call = true;
             }
             break;
         case OS.WM_PASTE:
-            OS.SendMessage (hwndText, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             newText = getClipboardText ();
             break;
         case OS.EM_UNDO:
@@ -2362,7 +2362,7 @@ LRESULT wmClipboard (HWND hwndText, int msg, WPARAM wParam, LPARAM lParam) {
                 OS.CallWindowProc (EditProc, hwndText, msg, wParam, lParam);
                 int length_ = OS.GetWindowTextLength (hwndText);
                 int newStart, newEnd;
-                OS.SendMessage (hwndText, OS.EM_GETSEL, &newStart, &newEnd);
+                OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                 if (length_ !is 0 && newStart  !is newEnd ) {
                     TCHAR[] buffer = new TCHAR [ length_ + 1];
                     OS.GetWindowText (hwndText, buffer.ptr, length_ + 1);
@@ -2404,7 +2404,7 @@ LRESULT wmClipboard (HWND hwndText, int msg, WPARAM wParam, LPARAM lParam) {
                 return new LRESULT (code);
             } else {
                 LPCTSTR buffer = StrToTCHARz( newText );
-                OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+                OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
                 return LRESULT.ZERO;
             }
         }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Control.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Control.d
@@ -2726,7 +2726,7 @@ public void setCapture (bool capture) {
 
 void setCursor () {
     LPARAM lParam = OS.MAKELPARAM (OS.HTCLIENT, OS.WM_MOUSEMOVE);
-    OS.SendMessage (handle, OS.WM_SETCURSOR, handle, lParam);
+    OS.SendMessage (handle, OS.WM_SETCURSOR, cast(WPARAM)handle, lParam);
 }
 
 /**
@@ -2774,7 +2774,7 @@ public void setCursor (Cursor cursor) {
 
 void setDefaultFont () {
     auto hFont = display.getSystemFont ().handle;
-    OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+    OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
 }
 
 /**
@@ -2884,7 +2884,7 @@ public void setFont (Font font) {
     }
     this.font = font;
     if (hFont is null) hFont = defaultFont ();
-    OS.SendMessage (handle, OS.WM_SETFONT, hFont, 1);
+    OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 1);
 }
 
 /**

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/CoolBar.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/CoolBar.d
@@ -195,7 +195,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
         int flags = OS.SWP_NOACTIVATE | OS.SWP_NOMOVE | OS.SWP_NOREDRAW | OS.SWP_NOZORDER;
         SetWindowPos (handle, null, 0, 0, newWidth, newHeight, flags);
         RECT rect;
-        OS.SendMessage (handle, OS.RB_GETRECT, count - 1, &rect);
+        OS.SendMessage (handle, OS.RB_GETRECT, count - 1, cast(LPARAM)&rect);
         height = Math.max (height, rect.bottom);
         SetWindowPos (handle, null, 0, 0, oldWidth, oldHeight, flags);
         REBARBANDINFO rbBand;
@@ -203,7 +203,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
         rbBand.fMask = OS.RBBIM_IDEALSIZE | OS.RBBIM_STYLE;
         int rowWidth = 0;
         for (int i = 0; i < count; i++) {
-            OS.SendMessage(handle, OS.RB_GETBANDINFO, i, &rbBand);
+            OS.SendMessage(handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
             if ((rbBand.fStyle & OS.RBBS_BREAK) !is 0) {
                 width = Math.max(width, rowWidth);
                 rowWidth = 0;
@@ -251,7 +251,7 @@ override void createHandle () {
     * create.
     */
     auto hFont = OS.GetStockObject (OS.SYSTEM_FONT);
-    OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+    OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
 }
 
 void createItem (CoolItem item, int index) {
@@ -303,7 +303,7 @@ void createItem (CoolItem item, int index) {
     }
 
     /* Insert the item */
-    if (OS.SendMessage (handle, OS.RB_INSERTBAND, index, &rbBand) is 0) {
+    if (OS.SendMessage (handle, OS.RB_INSERTBAND, index, cast(LPARAM)&rbBand) is 0) {
         error (SWT.ERROR_ITEM_NOT_ADDED);
     }
 
@@ -409,7 +409,7 @@ override void drawThemeBackground (HDC hDC, HWND hwnd, RECT* rect) {
     OS.MapWindowPoints (handle, hwnd, cast(POINT*) &rect2, 2);
     POINT lpPoint;
     OS.SetWindowOrgEx (hDC, -rect2.left, -rect2.top, &lpPoint);
-    OS.SendMessage (handle, OS.WM_PRINT, hDC, OS.PRF_CLIENT | OS.PRF_ERASEBKGND);
+    OS.SendMessage (handle, OS.WM_PRINT, cast(WPARAM)hDC, OS.PRF_CLIENT | OS.PRF_ERASEBKGND);
     OS.SetWindowOrgEx (hDC, lpPoint.x, lpPoint.y, null);
 }
 
@@ -422,11 +422,11 @@ int getMargin (int index) {
     int margin = 0;
     if (OS.COMCTL32_MAJOR >= 6) {
         MARGINS margins;
-        OS.SendMessage (handle, OS.RB_GETBANDMARGINS, 0, &margins);
+        OS.SendMessage (handle, OS.RB_GETBANDMARGINS, 0, cast(LPARAM)&margins);
         margin += margins.cxLeftWidth + margins.cxRightWidth;
     }
     RECT rect;
-    OS.SendMessage (handle, OS.RB_GETBANDBORDERS, index, &rect);
+    OS.SendMessage (handle, OS.RB_GETBANDBORDERS, index, cast(LPARAM)&rect);
     if ((style & SWT.FLAT) !is 0) {
         /*
         * Bug in Windows.  When the style bit  RBS_BANDBORDERS is not set
@@ -476,7 +476,7 @@ public CoolItem getItem (int index) {
     REBARBANDINFO rbBand;
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_ID;
-    OS.SendMessage (handle, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (handle, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
     return items [rbBand.wID];
 }
 
@@ -524,7 +524,7 @@ public int [] getItemOrder () {
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_ID;
     for (int i=0; i<count; i++) {
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
         CoolItem item = items [rbBand.wID];
         int index = 0;
         while (index<originalItems.length) {
@@ -561,7 +561,7 @@ public CoolItem [] getItems () {
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_ID;
     for (int i=0; i<count; i++) {
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
         result [i] = items [rbBand.wID];
     }
     return result;
@@ -590,10 +590,10 @@ public Point [] getItemSizes () {
     MARGINS margins;
     for (int i=0; i<count; i++) {
         RECT rect;
-        OS.SendMessage (handle, OS.RB_GETRECT, i, &rect);
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETRECT, i, cast(LPARAM)&rect);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
         if (OS.COMCTL32_MAJOR >= 6) {
-            OS.SendMessage (handle, OS.RB_GETBANDMARGINS, 0, &margins);
+            OS.SendMessage (handle, OS.RB_GETBANDMARGINS, 0, cast(LPARAM)&margins);
             rect.left -= margins.cxLeftWidth;
             rect.right += margins.cxRightWidth;
         }
@@ -614,7 +614,7 @@ ptrdiff_t getLastIndexOfRow (ptrdiff_t index) {
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_STYLE;
     for (auto i=index + 1; i<count; i++) {
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
         if ((rbBand.fStyle & OS.RBBS_BREAK) !is 0) {
             return i - 1;
         }
@@ -628,7 +628,7 @@ bool isLastItemOfRow (int index) {
     REBARBANDINFO rbBand;
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_STYLE;
-    OS.SendMessage (handle, OS.RB_GETBANDINFO, index + 1, &rbBand);
+    OS.SendMessage (handle, OS.RB_GETBANDINFO, index + 1, cast(LPARAM)&rbBand);
     return (rbBand.fStyle & OS.RBBS_BREAK) !is 0;
 }
 
@@ -712,13 +712,13 @@ void resizeToPreferredWidth (ptrdiff_t index) {
         REBARBANDINFO rbBand;
         rbBand.cbSize = REBARBANDINFO.sizeof;
         rbBand.fMask = OS.RBBIM_IDEALSIZE;
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, index, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
         RECT rect;
-        OS.SendMessage (handle, OS.RB_GETBANDBORDERS, index, &rect);
+        OS.SendMessage (handle, OS.RB_GETBANDBORDERS, index, cast(LPARAM)&rect);
         rbBand.cx = rbBand.cxIdeal + rect.left;
         if ((style & SWT.FLAT) is 0) rbBand.cx += rect.right;
         rbBand.fMask = OS.RBBIM_SIZE;
-        OS.SendMessage (handle, OS.RB_SETBANDINFO, index, &rbBand);
+        OS.SendMessage (handle, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
     }
 }
 
@@ -727,7 +727,7 @@ void resizeToMaximumWidth (ptrdiff_t index) {
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_SIZE;
     rbBand.cx = MAX_WIDTH;
-    OS.SendMessage (handle, OS.RB_SETBANDINFO, index, &rbBand);
+    OS.SendMessage (handle, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
 }
 
 override void releaseChildren (bool destroy) {
@@ -786,7 +786,7 @@ void setItemColors (int foreColor, int backColor) {
     rbBand.clrFore = foreColor;
     rbBand.clrBack = backColor;
     for (int i=0; i<count; i++) {
-        OS.SendMessage (handle, OS.RB_SETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_SETBANDINFO, i, cast(LPARAM)&rbBand);
     }
 }
 
@@ -916,7 +916,7 @@ void setItemSizes (Point [] sizes) {
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_ID;
     for (int i=0; i<count; i++) {
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
         items [rbBand.wID].setSize (sizes [i].x, sizes [i].y);
     }
 }
@@ -942,13 +942,13 @@ public void setLocked (bool locked) {
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_STYLE;
     for (int i=0; i<count; i++) {
-        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_GETBANDINFO, i, cast(LPARAM)&rbBand);
         if (locked) {
             rbBand.fStyle |= OS.RBBS_NOGRIPPER;
         } else {
             rbBand.fStyle &= ~OS.RBBS_NOGRIPPER;
         }
-        OS.SendMessage (handle, OS.RB_SETBANDINFO, i, &rbBand);
+        OS.SendMessage (handle, OS.RB_SETBANDINFO, i, cast(LPARAM)&rbBand);
     }
 }
 

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/CoolItem.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/CoolItem.d
@@ -231,10 +231,10 @@ public Rectangle getBounds () {
     if (index is -1) return new Rectangle (0, 0, 0, 0);
     auto hwnd = parent.handle;
     RECT rect;
-    OS.SendMessage (hwnd, OS.RB_GETRECT, index, &rect);
+    OS.SendMessage (hwnd, OS.RB_GETRECT, index, cast(LPARAM)&rect);
     if (OS.COMCTL32_MAJOR >= 6) {
         MARGINS margins;
-        OS.SendMessage (hwnd, OS.RB_GETBANDMARGINS, 0, &margins);
+        OS.SendMessage (hwnd, OS.RB_GETBANDMARGINS, 0, cast(LPARAM)&margins);
         rect.left -= margins.cxLeftWidth;
         rect.right += margins.cxRightWidth;
     }
@@ -255,9 +255,9 @@ Rectangle getClientArea () {
     if (index is -1) return new Rectangle (0, 0, 0, 0);
     auto hwnd = parent.handle;
     RECT insetRect;
-    OS.SendMessage (hwnd, OS.RB_GETBANDBORDERS, index, &insetRect);
+    OS.SendMessage (hwnd, OS.RB_GETBANDBORDERS, index, cast(LPARAM)&insetRect);
     RECT rect;
-    OS.SendMessage (hwnd, OS.RB_GETRECT, index, &rect);
+    OS.SendMessage (hwnd, OS.RB_GETRECT, index, cast(LPARAM)&rect);
     int x = rect.left + insetRect.left;
     int y = rect.top;
     int width = rect.right - rect.left - insetRect.left;
@@ -271,7 +271,7 @@ Rectangle getClientArea () {
         REBARBANDINFO rbBand;
         rbBand.cbSize = REBARBANDINFO.sizeof;
         rbBand.fMask = OS.RBBIM_HEADERSIZE;
-        OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+        OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
         width = width - rbBand.cxHeader + 1;
     }
     return new Rectangle (x, y, Math.max (0, width), Math.max (0, height));
@@ -361,7 +361,7 @@ public void setControl (Control control) {
     }
     bool hideNew = newControl !is null && !newControl.getVisible ();
     bool showOld = oldControl !is null && oldControl.getVisible ();
-    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
     if (hideNew) newControl.setVisible (false);
     if (showOld) oldControl.setVisible (true);
     if (hwndAbove !is null && hwndAbove !is hwndChild) {
@@ -390,7 +390,7 @@ public Point getPreferredSize () {
     REBARBANDINFO rbBand;
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_CHILDSIZE | OS.RBBIM_IDEALSIZE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
     int width = rbBand.cxIdeal + parent.getMargin (index);
     if ((parent.style & SWT.VERTICAL) !is 0) {
         return new Point (rbBand.cyMaxChild, width);
@@ -430,14 +430,14 @@ public void setPreferredSize (int width, int height) {
 
     /* Get the child size fields first so we don't overwrite them. */
     rbBand.fMask = OS.RBBIM_CHILDSIZE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
 
     /* Set the size fields we are currently modifying. */
     rbBand.fMask = OS.RBBIM_CHILDSIZE | OS.RBBIM_IDEALSIZE;
     rbBand.cxIdeal = cxIdeal;
     rbBand.cyMaxChild = cyMaxChild;
     if (!minimum) rbBand.cyMinChild = cyMaxChild;
-    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
 }
 
 /**
@@ -478,10 +478,10 @@ public Point getSize() {
     if (index is -1) new Point (0, 0);
     auto hwnd = parent.handle;
     RECT rect;
-    OS.SendMessage (hwnd, OS.RB_GETRECT, index, &rect);
+    OS.SendMessage (hwnd, OS.RB_GETRECT, index, cast(LPARAM)&rect);
     if (OS.COMCTL32_MAJOR >= 6) {
         MARGINS margins;
-        OS.SendMessage (hwnd, OS.RB_GETBANDMARGINS, 0, &margins);
+        OS.SendMessage (hwnd, OS.RB_GETBANDMARGINS, 0, cast(LPARAM)&margins);
         rect.left -= margins.cxLeftWidth;
         rect.right += margins.cxRightWidth;
     }
@@ -534,7 +534,7 @@ public void setSize (int width, int height) {
 
     /* Get the child size fields first so we don't overwrite them. */
     rbBand.fMask = OS.RBBIM_CHILDSIZE | OS.RBBIM_IDEALSIZE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
 
     /* Set the size fields we are currently modifying. */
     if (!ideal) rbBand.cxIdeal = cxIdeal;
@@ -547,14 +547,14 @@ public void setSize (int width, int height) {
     if (!parent.isLastItemOfRow (index)) {
         if (OS.COMCTL32_MAJOR >= 6) {
             MARGINS margins;
-            OS.SendMessage (hwnd, OS.RB_GETBANDMARGINS, 0, &margins);
+            OS.SendMessage (hwnd, OS.RB_GETBANDMARGINS, 0, cast(LPARAM)&margins);
             cx -= margins.cxLeftWidth + margins.cxRightWidth;
         }
         int separator = (parent.style & SWT.FLAT) is 0 ? CoolBar.SEPARATOR_WIDTH : 0;
         rbBand.cx = cx - separator;
         rbBand.fMask |= OS.RBBIM_SIZE;
     }
-    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
 }
 
 /**
@@ -601,7 +601,7 @@ public Point getMinimumSize () {
     REBARBANDINFO rbBand;
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_CHILDSIZE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
     if ((parent.style & SWT.VERTICAL) !is 0) {
         return new Point (rbBand.cyMinChild, rbBand.cxMinChild);
     }
@@ -643,12 +643,12 @@ public void setMinimumSize (int width, int height) {
 
     /* Get the child size fields first so we don't overwrite them. */
     rbBand.fMask = OS.RBBIM_CHILDSIZE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
 
     /* Set the size fields we are currently modifying. */
     rbBand.cxMinChild = cxMinChild;
     rbBand.cyMinChild = cyMinChild;
-    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
 }
 
 /**
@@ -679,7 +679,7 @@ bool getWrap() {
     REBARBANDINFO rbBand;
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_STYLE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
     return (rbBand.fStyle & OS.RBBS_BREAK) !is 0;
 }
 
@@ -689,13 +689,13 @@ void setWrap(bool wrap) {
     REBARBANDINFO rbBand;
     rbBand.cbSize = REBARBANDINFO.sizeof;
     rbBand.fMask = OS.RBBIM_STYLE;
-    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_GETBANDINFO, index, cast(LPARAM)&rbBand);
     if (wrap) {
         rbBand.fStyle |= OS.RBBS_BREAK;
     } else {
         rbBand.fStyle &= ~OS.RBBS_BREAK;
     }
-    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, &rbBand);
+    OS.SendMessage (hwnd, OS.RB_SETBANDINFO, index, cast(LPARAM)&rbBand);
 }
 
 /**

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/DateTime.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/DateTime.d
@@ -202,7 +202,7 @@ public this (Composite parent, int style) {
     if ((this.style & SWT.SHORT) !is 0) {
         String buffer = ((this.style & SWT.DATE) !is 0) ? getCustomShortDateFormat() : getCustomShortTimeFormat();
         StringT lpszFormat = StrToTCHARs (0, buffer, true);
-        OS.SendMessage (handle, OS.DTM_SETFORMAT, 0, cast(void*)lpszFormat.ptr);
+        OS.SendMessage (handle, OS.DTM_SETFORMAT, 0, cast(LPARAM)lpszFormat.ptr);
     }
 }
 
@@ -266,7 +266,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
     if (wHint is SWT.DEFAULT || hHint is SWT.DEFAULT) {
         if ((style & SWT.CALENDAR) !is 0) {
             RECT rect;
-            OS.SendMessage(handle, OS.MCM_GETMINREQRECT, 0, &rect);
+            OS.SendMessage(handle, OS.MCM_GETMINREQRECT, 0, cast(LPARAM)&rect);
             width = rect.right;
             height = rect.bottom;
         } else {
@@ -565,7 +565,7 @@ public int getDay () {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     return systime.wDay;
 }
 
@@ -587,7 +587,7 @@ public int getHours () {
     if ((style & SWT.CALENDAR) !is 0) return time.wHour;
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     return systime.wHour;
 }
 
@@ -609,7 +609,7 @@ public int getMinutes () {
     if ((style & SWT.CALENDAR) !is 0) return time.wMinute;
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     return systime.wMinute;
 }
 
@@ -630,7 +630,7 @@ public int getMonth () {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     return systime.wMonth - 1;
 }
 
@@ -657,7 +657,7 @@ public int getSeconds () {
     if ((style & SWT.CALENDAR) !is 0) return time.wSecond;
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     return systime.wSecond;
 }
 
@@ -678,7 +678,7 @@ public int getYear () {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     return systime.wYear;
 }
 
@@ -735,12 +735,12 @@ public void setDate (int year, int month, int day) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wYear = cast(short)year;
     systime.wMonth = cast(short)(month + 1);
     systime.wDay = cast(short)day;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     lastSystemTime = null;
 }
 
@@ -761,10 +761,10 @@ public void setDay (int day) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wDay = cast(short)day;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     lastSystemTime = null;
 }
 
@@ -785,10 +785,10 @@ public void setHours (int hours) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wHour = cast(short)hours;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     if ((style & SWT.CALENDAR) !is 0 && hours >= 0 && hours <= 23) time.wHour = cast(short)hours;
 }
 
@@ -809,10 +809,10 @@ public void setMinutes (int minutes) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wMinute = cast(short)minutes;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     if ((style & SWT.CALENDAR) !is 0 && minutes >= 0 && minutes <= 59) time.wMinute = cast(short)minutes;
 }
 
@@ -833,10 +833,10 @@ public void setMonth (int month) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wMonth = cast(short)(month + 1);
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     lastSystemTime = null;
 }
 
@@ -857,10 +857,10 @@ public void setSeconds (int seconds) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wSecond = cast(short)seconds;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     if ((style & SWT.CALENDAR) !is 0 && seconds >= 0 && seconds <= 59) time.wSecond = cast(short)seconds;
 }
 
@@ -882,12 +882,12 @@ public void setTime (int hours, int minutes, int seconds) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wHour = cast(short)hours;
     systime.wMinute = cast(short)minutes;
     systime.wSecond = cast(short)seconds;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     if ((style & SWT.CALENDAR) !is 0
             && hours >= 0 && hours <= 23
             && minutes >= 0 && minutes <= 59
@@ -915,10 +915,10 @@ public void setYear (int year) {
     checkWidget ();
     SYSTEMTIME systime;
     int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_SETCURSEL : OS.DTM_SETSYSTEMTIME;
     systime.wYear = cast(short)year;
-    OS.SendMessage (handle, msg, 0, &systime);
+    OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
     lastSystemTime = null;
 }
 
@@ -951,7 +951,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
             if (ignoreSelection) break;
             SYSTEMTIME systime;
             int msg = (style & SWT.CALENDAR) !is 0 ? OS.MCM_GETCURSEL : OS.DTM_GETSYSTEMTIME;
-            OS.SendMessage (handle, msg, 0, &systime);
+            OS.SendMessage (handle, msg, 0, cast(LPARAM)&systime);
             if (lastSystemTime is null || systime.wDay !is lastSystemTime.wDay || systime.wMonth !is lastSystemTime.wMonth || systime.wYear !is lastSystemTime.wYear) {
                 postEvent (SWT.Selection);
                 if ((style & SWT.TIME) is 0) {

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Decorations.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Decorations.d
@@ -383,12 +383,12 @@ override public Rectangle computeTrim (int x, int y, int width, int height) {
     if (hasMenu) {
         RECT testRect;
         OS.SetRect (&testRect, 0, 0, rect.right - rect.left, rect.bottom - rect.top);
-        OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, &testRect);
+        OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, cast(LPARAM)&testRect);
         while ((testRect.bottom - testRect.top) < height) {
             if (testRect.bottom - testRect.top is 0) break;
             rect.top -= OS.GetSystemMetrics (OS.SM_CYMENU) - OS.GetSystemMetrics (OS.SM_CYBORDER);
             OS.SetRect (&testRect, 0, 0, rect.right - rect.left, rect.bottom - rect.top);
-            OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, &testRect);
+            OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, cast(LPARAM)&testRect);
         }
     }
     return new Rectangle (rect.left, rect.top, rect.right - rect.left, rect.bottom - rect.top);
@@ -1017,7 +1017,7 @@ void setImages (Image image, Image [] images) {
             default:
         }
     }
-    OS.SendMessage (handle, OS.WM_SETICON, OS.ICON_SMALL, hSmallIcon);
+    OS.SendMessage (handle, OS.WM_SETICON, OS.ICON_SMALL, cast(LPARAM)hSmallIcon);
     if (largeIcon !is null) {
         switch (largeIcon.type) {
             case SWT.BITMAP:
@@ -1030,7 +1030,7 @@ void setImages (Image image, Image [] images) {
             default:
         }
     }
-    OS.SendMessage (handle, OS.WM_SETICON, OS.ICON_BIG, hLargeIcon);
+    OS.SendMessage (handle, OS.WM_SETICON, OS.ICON_BIG, cast(LPARAM)hLargeIcon);
 
     /*
     * Bug in Windows.  When WM_SETICON is used to remove an

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/DirectoryDialog.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/DirectoryDialog.d
@@ -103,7 +103,7 @@ extern(Windows)static int BrowseCallbackProc (HWND hwnd, uint uMsg, LPARAM lPara
             if (pThis.filterPath !is null && pThis.filterPath.length !is 0) {
                 /* Use the character encoding for the default locale */
                 StringT buffer = StrToTCHARs (0, pThis.filterPath.replace ('/', '\\'), true);
-                OS.SendMessage (hwnd, OS.BFFM_SETSELECTION, 1, cast(void*)buffer.ptr);
+                OS.SendMessage (hwnd, OS.BFFM_SETSELECTION, 1, cast(LPARAM)buffer.ptr);
             }
             if (pThis.title !is null && pThis.title.length !is 0) {
                 /* Use the character encoding for the default locale */

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Display.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Display.d
@@ -4617,11 +4617,11 @@ ptrdiff_t windowProc(){
     */
     if (columnVisible !is null) {
         if (msg is OS.WM_NOTIFY && hwndParent is hwnd) {
-            OS.MoveMemory (hdr, lParam, NMHDR.sizeof);
+            OS.MoveMemory (hdr, cast(LPCVOID)lParam, NMHDR.sizeof);
             switch (hdr.code) {
                 case OS.LVN_GETDISPINFOA:
                 case OS.LVN_GETDISPINFOW: {
-                    OS.MoveMemory (plvfi, lParam, OS.NMLVDISPINFO_sizeof);
+                    OS.MoveMemory (plvfi, cast(LPCVOID)lParam, OS.NMLVDISPINFO_sizeof);
                     if (0 <= plvfi.item.iSubItem && plvfi.item.iSubItem < columnCount) {
                         if (!columnVisible [plvfi.item.iSubItem]) return 0;
                     }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Group.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Group.d
@@ -340,7 +340,7 @@ void printWidget (HWND hwnd, GC gc) {
         * the children, drawing each one.
         */
         int flags = OS.PRF_CLIENT | OS.PRF_NONCLIENT | OS.PRF_ERASEBKGND;
-        OS.SendMessage (hwnd, OS.WM_PRINT, hDC, flags);
+        OS.SendMessage (hwnd, OS.WM_PRINT, cast(WPARAM)hDC, flags);
         int nSavedDC = OS.SaveDC (hDC);
         Control [] children = _getChildren ();
         Rectangle rect = getBounds ();
@@ -541,7 +541,7 @@ override LRESULT WM_WINDOWPOSCHANGING (WPARAM wParam, LPARAM lParam) {
     }
     RECT rect;
     OS.SetRect (&rect, 0, 0, lpwp.cx, lpwp.cy);
-    OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, &rect);
+    OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, cast(LPARAM)&rect);
     int newWidth = rect.right - rect.left;
     int newHeight = rect.bottom - rect.top;
     OS.GetClientRect (handle, &rect);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/IME.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/IME.d
@@ -573,7 +573,7 @@ LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                     offset = event.index + event.count - startOffset;
                     int trailing = event.count > 0 ? 1 : 2;
                     auto param = OS.MAKEWPARAM (OS.MAKEWORD (OS.IMEMOUSE_LDOWN, trailing), offset);
-                    OS.SendMessage (imeWnd, WM_MSIME_MOUSE, param, hIMC);
+                    OS.SendMessage (imeWnd, WM_MSIME_MOUSE, param, cast(LPARAM)hIMC);
                 } else {
                     OS.ImmNotifyIME (hIMC, OS.NI_COMPOSITIONSTR, OS.CPS_COMPLETE, 0);
                 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Link.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Link.d
@@ -334,7 +334,7 @@ override void enableWidget (bool enabled) {
         item.mask = OS.LIF_ITEMINDEX | OS.LIF_STATE;
         item.stateMask = OS.LIS_ENABLED;
         item.state = enabled ? OS.LIS_ENABLED : 0;
-        while (OS.SendMessage (handle, OS.LM_SETITEM, 0, &item) !is 0) {
+        while (OS.SendMessage (handle, OS.LM_SETITEM, 0, cast(LPARAM)&item) !is 0) {
             item.iLink++;
         }
     } else {
@@ -805,7 +805,7 @@ override LRESULT WM_GETDLGCODE (WPARAM wParam, LPARAM lParam) {
         item.mask = OS.LIF_ITEMINDEX | OS.LIF_STATE;
         item.stateMask = OS.LIS_FOCUSED;
         index = 0;
-        while (OS.SendMessage (handle, OS.LM_GETITEM, 0, &item) !is 0) {
+        while (OS.SendMessage (handle, OS.LM_GETITEM, 0, cast(LPARAM)&item) !is 0) {
             if ((item.state & OS.LIS_FOCUSED) !is 0) {
                 index = item.iLink;
             }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/List.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/List.d
@@ -124,7 +124,7 @@ public void add (String string) {
     // SWT extension: allow null string
     //if (string is null) error (SWT.ERROR_NULL_ARGUMENT);
     LPCTSTR buffer = StrToTCHARz ( getCodePage (), string);
-    auto result = OS.SendMessage (handle, OS.LB_ADDSTRING, 0, cast(void*)buffer);
+    auto result = OS.SendMessage (handle, OS.LB_ADDSTRING, 0, cast(LPARAM)buffer);
     if (result is OS.LB_ERR) error (SWT.ERROR_ITEM_NOT_ADDED);
     if (result is OS.LB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
     if ((style & SWT.H_SCROLL) !is 0) setScrollWidth (buffer, true);
@@ -157,7 +157,7 @@ public void add (String string, int index) {
     //if (string is null) error (SWT.ERROR_NULL_ARGUMENT);
     if (index is -1) error (SWT.ERROR_INVALID_RANGE);
     LPCTSTR buffer = StrToTCHARz(getCodePage (), string);
-    auto result = OS.SendMessage (handle, OS.LB_INSERTSTRING, index, cast(void*)buffer);
+    auto result = OS.SendMessage (handle, OS.LB_INSERTSTRING, index, cast(LPARAM)buffer);
     if (result is OS.LB_ERRSPACE) error (SWT.ERROR_ITEM_NOT_ADDED);
     if (result is OS.LB_ERR) {
         auto count = OS.SendMessage (handle, OS.LB_GETCOUNT, 0, 0);
@@ -256,7 +256,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
                     if (length + 1 > buffer.length) {
                         buffer = NewTCHARs (cp, length + 1);
                     }
-                    auto result = OS.SendMessage (handle, OS.LB_GETTEXT, i, buffer.ptr);
+                    auto result = OS.SendMessage (handle, OS.LB_GETTEXT, i, cast(LPARAM)buffer.ptr);
                     if (result !is OS.LB_ERR) {
                         OS.DrawText (hDC, buffer.ptr, length, &rect, flags);
                         width = Math.max (width, rect.right - rect.left);
@@ -452,7 +452,7 @@ public String getItem (int index) {
     auto length_ = OS.SendMessage (handle, OS.LB_GETTEXTLEN, index, 0);
     if (length_ !is OS.LB_ERR) {
         TCHAR[] buffer = NewTCHARs (getCodePage (), length_ + 1);
-        auto result = OS.SendMessage (handle, OS.LB_GETTEXT, index, buffer.ptr);
+        auto result = OS.SendMessage (handle, OS.LB_GETTEXT, index, cast(LPARAM)buffer.ptr);
         if (result !is OS.LB_ERR) return TCHARsToStr( buffer[0 .. length_] );
     }
     auto count = OS.SendMessage (handle, OS.LB_GETCOUNT, 0, 0);
@@ -592,7 +592,7 @@ public int getSelectionIndex () {
     if (result is OS.LB_ERR) error (SWT.ERROR_CANNOT_GET_SELECTION);
     if (result !is 0) return cast(int)/*64bit*/index;
     INT_PTR buffer;
-    result = OS.SendMessage (handle, OS.LB_GETSELITEMS, 1, &buffer);
+    result = OS.SendMessage (handle, OS.LB_GETSELITEMS, 1, cast(LPARAM)&buffer);
     if (result !is 1) error (SWT.ERROR_CANNOT_GET_SELECTION);
     return cast(int)/*64bit*/buffer;
 }
@@ -623,7 +623,7 @@ public int [] getSelectionIndices () {
     auto length = OS.SendMessage (handle, OS.LB_GETSELCOUNT, 0, 0);
     if (length is OS.LB_ERR) error (SWT.ERROR_CANNOT_GET_SELECTION);
     int [] indices = new int [length];
-    auto result = OS.SendMessage (handle, OS.LB_GETSELITEMS, length, indices.ptr);
+    auto result = OS.SendMessage (handle, OS.LB_GETSELITEMS, length, cast(LPARAM)indices.ptr);
     if (result !is length) error (SWT.ERROR_CANNOT_GET_SELECTION);
     return indices;
 }
@@ -706,7 +706,7 @@ public int indexOf (String string, int start) {
     int index = start - 1, last;
     LPCTSTR buffer = StrToTCHARz (getCodePage (), string );
     do {
-        index = cast(int)/*64bit*/OS.SendMessage (handle, OS.LB_FINDSTRINGEXACT, last = index, cast(void*)buffer);
+        index = cast(int)/*64bit*/OS.SendMessage (handle, OS.LB_FINDSTRINGEXACT, last = index, cast(LPARAM)buffer);
         if (index is OS.LB_ERR || index <= last) return -1;
     } while (string !=/*eq*/ getItem (index));
     return index;
@@ -779,7 +779,7 @@ public void remove (int [] indices) {
                 auto length = OS.SendMessage (handle, OS.LB_GETTEXTLEN, index, 0);
                 if (length is OS.LB_ERR) break;
                 buffer = NewTCHARs (cp, length + 1);
-                auto result = OS.SendMessage (handle, OS.LB_GETTEXT, index, buffer.ptr);
+                auto result = OS.SendMessage (handle, OS.LB_GETTEXT, index, cast(LPARAM)buffer.ptr);
                 if (result is OS.LB_ERR) break;
             }
             auto result = OS.SendMessage (handle, OS.LB_DELETESTRING, index, 0);
@@ -831,7 +831,7 @@ public void remove (int index) {
             error (SWT.ERROR_INVALID_RANGE);
         }
         buffer = NewTCHARs (getCodePage (), length + 1);
-        auto result = OS.SendMessage (handle, OS.LB_GETTEXT, index, buffer.ptr);
+        auto result = OS.SendMessage (handle, OS.LB_GETTEXT, index, cast(LPARAM)buffer.ptr);
         if (result is OS.LB_ERR) {
             auto count = OS.SendMessage (handle, OS.LB_GETCOUNT, 0, 0);
             if (0 <= index && index < count) error (SWT.ERROR_ITEM_NOT_REMOVED);
@@ -898,7 +898,7 @@ public void remove (int start, int end) {
             auto length = OS.SendMessage (handle, OS.LB_GETTEXTLEN, start, 0);
             if (length is OS.LB_ERR) break;
             buffer = NewTCHARs (cp, length + 1);
-            auto result = OS.SendMessage (handle, OS.LB_GETTEXT, start, buffer.ptr);
+            auto result = OS.SendMessage (handle, OS.LB_GETTEXT, start, cast(LPARAM)buffer.ptr);
             if (result is OS.LB_ERR) break;
         }
         auto result = OS.SendMessage (handle, OS.LB_DELETESTRING, start, 0);
@@ -1058,7 +1058,7 @@ void select (int index, bool scroll) {
     auto topIndex = OS.SendMessage (handle, OS.LB_GETTOPINDEX, 0, 0);
     RECT itemRect, selectedRect;
     bool selectedRectNull = true;
-    OS.SendMessage (handle, OS.LB_GETITEMRECT, index, &itemRect);
+    OS.SendMessage (handle, OS.LB_GETITEMRECT, index, cast(LPARAM)&itemRect);
     bool redraw = drawCount is 0 && OS.IsWindowVisible (handle);
     if (redraw) {
         OS.UpdateWindow (handle);
@@ -1070,7 +1070,7 @@ void select (int index, bool scroll) {
         if (oldIndex !is -1) {
             //selectedRect = new RECT ();
             selectedRectNull = false;
-            OS.SendMessage (handle, OS.LB_GETITEMRECT, oldIndex, &selectedRect);
+            OS.SendMessage (handle, OS.LB_GETITEMRECT, oldIndex, cast(LPARAM)&selectedRect);
         }
         OS.SendMessage (handle, OS.LB_SETCURSEL, index, 0);
     } else {
@@ -1244,7 +1244,7 @@ public void setItems (String [] items) {
     while (index < length) {
         String string = items [index];
         LPCTSTR buffer = StrToTCHARz (cp, string);
-        auto result = OS.SendMessage (handle, OS.LB_ADDSTRING, 0, cast(void*)buffer);
+        auto result = OS.SendMessage (handle, OS.LB_ADDSTRING, 0, cast(LPARAM)buffer);
         if (result is OS.LB_ERR || result is OS.LB_ERRSPACE) break;
         if ((style & SWT.H_SCROLL) !is 0) {
             int flags = OS.DT_CALCRECT | OS.DT_SINGLELINE | OS.DT_NOPREFIX;
@@ -1289,7 +1289,7 @@ void setScrollWidth () {
         auto length = OS.SendMessage (handle, OS.LB_GETTEXTLEN, i, 0);
         if (length !is OS.LB_ERR) {
             TCHAR[] buffer = NewTCHARs (cp, length + 1 );
-            auto result = OS.SendMessage (handle, OS.LB_GETTEXT, i, buffer.ptr);
+            auto result = OS.SendMessage (handle, OS.LB_GETTEXT, i, cast(LPARAM)buffer.ptr);
             if (result !is OS.LB_ERR) {
                 OS.DrawText (hDC, buffer.ptr, -1, &rect, flags);
                 newWidth = Math.max (newWidth, rect.right - rect.left);
@@ -1507,7 +1507,7 @@ public void showSelection () {
         index = OS.SendMessage (handle, OS.LB_GETCURSEL, 0, 0);
     } else {
         .LRESULT indices;
-        auto result = OS.SendMessage (handle, OS.LB_GETSELITEMS, 1, &indices);
+        auto result = OS.SendMessage (handle, OS.LB_GETSELITEMS, 1, cast(LPARAM)&indices);
         index = indices;
         if (result !is 1) index = -1;
     }
@@ -1677,7 +1677,7 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
             * focus item.
             */
             RECT itemRect;
-            OS.SendMessage (handle, OS.LB_GETITEMRECT, newIndex, &itemRect);
+            OS.SendMessage (handle, OS.LB_GETITEMRECT, newIndex, cast(LPARAM)&itemRect);
             OS.InvalidateRect (handle, &itemRect, true);
         }
         return new LRESULT (code);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Menu.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Menu.d
@@ -474,7 +474,7 @@ void createItem (MenuItem item, int index) {
         if ((item.style & SWT.SEPARATOR) !is 0) lpButton.fsStyle = cast(byte) OS.BTNS_SEP;
         lpButton.fsState = cast(byte) OS.TBSTATE_ENABLED;
         lpButton.iBitmap = OS.I_IMAGENONE;
-        success = OS.SendMessage (hwndCB, OS.TB_INSERTBUTTON, index, &lpButton) !is 0;
+        success = OS.SendMessage (hwndCB, OS.TB_INSERTBUTTON, index, cast(LPARAM)&lpButton) !is 0;
     } else {
         static if (OS.IsWinCE) {
             int uFlags = OS.MF_BYPOSITION;
@@ -864,7 +864,7 @@ public MenuItem [] getItems () {
         TBBUTTON lpButton;
         MenuItem [] result = new MenuItem [count];
         for (int i=0; i<count; i++) {
-            OS.SendMessage (hwndCB, OS.TB_GETBUTTON, i, &lpButton);
+            OS.SendMessage (hwndCB, OS.TB_GETBUTTON, i, cast(LPARAM)&lpButton);
             result [i] = display.getMenuItem (lpButton.idCommand);
         }
         return result;
@@ -1032,7 +1032,7 @@ int imageIndex (Image image) {
         imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height);
         int index = imageList.add (image);
         HANDLE hImageList = imageList.getHandle ();
-        OS.SendMessage (hwndCB, OS.TB_SETIMAGELIST, 0, hImageList);
+        OS.SendMessage (hwndCB, OS.TB_SETIMAGELIST, 0, cast(LPARAM)hImageList);
         return index;
     }
     int index = imageList.indexOf (image);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/MenuItem.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/MenuItem.d
@@ -428,7 +428,7 @@ public bool getEnabled () {
         TBBUTTONINFO info;
         info.cbSize = TBBUTTONINFO.sizeof;
         info.dwMask = OS.TBIF_STATE;
-        OS.SendMessage (hwndCB, OS.TB_GETBUTTONINFO, id, &info);
+        OS.SendMessage (hwndCB, OS.TB_GETBUTTONINFO, id, cast(LPARAM)&info);
         return (info.fsState & OS.TBSTATE_ENABLED) !is 0;
     }
     /*
@@ -697,10 +697,10 @@ public void setEnabled (bool enabled) {
         TBBUTTONINFO info;
         info.cbSize = TBBUTTONINFO.sizeof;
         info.dwMask = OS.TBIF_STATE;
-        OS.SendMessage (hwndCB, OS.TB_GETBUTTONINFO, id, &info);
+        OS.SendMessage (hwndCB, OS.TB_GETBUTTONINFO, id, cast(LPARAM)&info);
         info.fsState &= ~OS.TBSTATE_ENABLED;
         if (enabled) info.fsState |= OS.TBSTATE_ENABLED;
-        OS.SendMessage (hwndCB, OS.TB_SETBUTTONINFO, id, &info);
+        OS.SendMessage (hwndCB, OS.TB_SETBUTTONINFO, id, cast(LPARAM)&info);
     } else {
         /*
         * Feature in Windows.  For some reason, when the menu item
@@ -861,7 +861,7 @@ void setMenu (Menu menu, bool dispose) {
         if (OS.IsPPC) {
             HWND hwndCB = parent.hwndCB;
             HMENU hMenu = menu is null ? null : menu.handle;
-            OS.SendMessage (hwndCB, OS.SHCMBM_SETSUBMENU, id, hMenu);
+            OS.SendMessage (hwndCB, OS.SHCMBM_SETSUBMENU, id, cast(LPARAM)hMenu);
         }
         if (OS.IsSP) error (SWT.ERROR_CANNOT_SET_MENU);
     } else {
@@ -1078,7 +1078,7 @@ override public void setText (String string) {
         info2.cbSize = TBBUTTONINFO.sizeof;
         info2.dwMask = OS.TBIF_TEXT;
         info2.pszText = pszText;
-        success = OS.SendMessage (hwndCB, OS.TB_SETBUTTONINFO, id, &info2) !is 0;
+        success = OS.SendMessage (hwndCB, OS.TB_SETBUTTONINFO, id, cast(LPARAM)&info2) !is 0;
     } else {
         MENUITEMINFO info;
         info.cbSize = OS.MENUITEMINFO_sizeof;

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Scale.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Scale.d
@@ -181,7 +181,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
     int border = getBorderWidth ();
     int width = border * 2, height = border * 2;
     RECT rect;
-    OS.SendMessage (handle, OS.TBM_GETTHUMBRECT, 0, &rect);
+    OS.SendMessage (handle, OS.TBM_GETTHUMBRECT, 0, cast(LPARAM)&rect);
     if ((style & SWT.HORIZONTAL) !is 0) {
         width += OS.GetSystemMetrics (OS.SM_CXHSCROLL) * 10;
         int scrollY = OS.GetSystemMetrics (OS.SM_CYHSCROLL);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Shell.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Shell.d
@@ -653,7 +653,7 @@ void createToolTip (ToolTip toolTip) {
     lpti.uId = toolTip.id;
     lpti.uFlags = OS.TTF_TRACK;
     lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
-    OS.SendMessage (toolTip.hwndToolTip (), OS.TTM_ADDTOOL, 0, &lpti);
+    OS.SendMessage (toolTip.hwndToolTip (), OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
 }
 
 void createToolTipHandle () {
@@ -698,7 +698,7 @@ void destroyToolTip (ToolTip toolTip) {
         lpti.cbSize = OS.TOOLINFO_sizeof;
         lpti.uId = toolTip.id;
         lpti.hwnd = handle;
-        OS.SendMessage (balloonTipHandle_, OS.TTM_DELTOOL, 0, &lpti);
+        OS.SendMessage (balloonTipHandle_, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
     }
     toolTip.id = -1;
 }
@@ -846,10 +846,10 @@ void fixToolTip () {
         if (toolTipHandle_ is null) return;
         TOOLINFO lpti;
         lpti.cbSize = OS.TOOLINFO_sizeof;
-        if (OS.SendMessage (toolTipHandle_, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+        if (OS.SendMessage (toolTipHandle_, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
             if ((lpti.uFlags & OS.TTF_IDISHWND) !is 0) {
-                OS.SendMessage (toolTipHandle_, OS.TTM_DELTOOL, 0, &lpti);
-                OS.SendMessage (toolTipHandle_, OS.TTM_ADDTOOL, 0, &lpti);
+                OS.SendMessage (toolTipHandle_, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
+                OS.SendMessage (toolTipHandle_, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
             }
         }
     }
@@ -939,7 +939,7 @@ ToolTip getCurrentToolTip (HWND hwndToolTip) {
     if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, 0) !is 0) {
         TOOLINFO lpti;
         lpti.cbSize = OS.TOOLINFO_sizeof;
-        if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+        if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
             if ((lpti.uFlags & OS.TTF_IDISHWND) is 0) return findToolTip (lpti.uId);
         }
     }
@@ -1684,14 +1684,14 @@ void setToolTipText (HWND hwnd, String text) {
     lpti.uId = cast(ptrdiff_t)hwnd;
     auto hwndToolTip = toolTipHandle ();
     if (text is null) {
-        OS.SendMessage (hwndToolTip, OS.TTM_DELTOOL, 0, &lpti);
+        OS.SendMessage (hwndToolTip, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
     } else {
-        if (OS.SendMessage (hwndToolTip, OS.TTM_GETTOOLINFO, 0, &lpti) !is 0) {
+        if (OS.SendMessage (hwndToolTip, OS.TTM_GETTOOLINFO, 0, cast(LPARAM)&lpti) !is 0) {
             OS.SendMessage (hwndToolTip, OS.TTM_UPDATE, 0, 0);
         } else {
             lpti.uFlags = OS.TTF_IDISHWND | OS.TTF_SUBCLASS;
             lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
-            OS.SendMessage (hwndToolTip, OS.TTM_ADDTOOL, 0, &lpti);
+            OS.SendMessage (hwndToolTip, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
         }
     }
 }
@@ -1770,7 +1770,7 @@ void setToolTipTitle (HWND hwndToolTip, String text, HICON icon) {
         else {
             LPCTSTR pszTitle = StrToTCHARz( text, getCodePage ());
         }
-        OS.SendMessage (hwndToolTip, OS.TTM_SETTITLE, icon, cast(LPARAM)pszTitle);
+        OS.SendMessage (hwndToolTip, OS.TTM_SETTITLE, cast(WPARAM)icon, cast(LPARAM)pszTitle);
     } else {
         OS.SendMessage (hwndToolTip, OS.TTM_SETTITLE, 0, 0);
     }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Spinner.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Spinner.d
@@ -327,7 +327,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
         height = tm.tmHeight;
         RECT rect;
         int max;
-        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, null, &max);
+        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, 0, cast(LPARAM)&max);
         String string = String_valueOf( max );
         if (digits > 0) {
             StringBuffer buffer = new StringBuffer ();
@@ -486,7 +486,7 @@ String getDecimalSeparator () {
 public int getIncrement () {
     checkWidget ();
     UDACCEL udaccel;
-    OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, 1, &udaccel);
+    OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, 1, cast(LPARAM)&udaccel);
     return udaccel.nInc;
 }
 
@@ -503,7 +503,7 @@ public int getIncrement () {
 public int getMaximum () {
     checkWidget ();
     int max;
-    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, null, &max);
+    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, 0, cast(LPARAM)&max);
     return max;
 }
 
@@ -520,7 +520,7 @@ public int getMaximum () {
 public int getMinimum () {
     checkWidget ();
     int min;
-    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, null);
+    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, 0);
     return min;
 }
 
@@ -594,7 +594,7 @@ int getSelectionText (bool [] parseFail) {
             value = Integer.parseInt (string);
         }
         int max, min;
-        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, &max);
+        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, cast(LPARAM)&max);
         if (min <= value && value <= max) return value;
     } catch (NumberFormatException e) {
     }
@@ -799,7 +799,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
     /* Verify the character */
     String oldText = "";
     int start, end;
-    OS.SendMessage (hwndText, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     switch (key) {
         case 0x08:  /* Bs */
             if (start is end) {
@@ -808,7 +808,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
                 if (!OS.IsUnicode && OS.IsDBLocale) {
                     int newStart, newEnd;
                     OS.SendMessage (hwndText, OS.EM_SETSEL, start, end);
-                    OS.SendMessage (hwndText, OS.EM_GETSEL, &newStart, &newEnd);
+                    OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                     if (start !is newStart) start = start - 1;
                 }
                 start = Math.max (start, 0);
@@ -822,7 +822,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
                 if (!OS.IsUnicode && OS.IsDBLocale) {
                     int newStart, newEnd;
                     OS.SendMessage (hwndText, OS.EM_SETSEL, start, end);
-                    OS.SendMessage (hwndText, OS.EM_GETSEL, &newStart, &newEnd);
+                    OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                     if (end !is newEnd) end = end + 1;
                 }
                 end = Math.min (end, length_);
@@ -840,7 +840,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
     if (newText is oldText) return true;
     LPCTSTR buffer = StrToTCHARz (getCodePage (), newText);
     OS.SendMessage (hwndText, OS.EM_SETSEL, start, end);
-    OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+    OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
     return false;
 }
 
@@ -909,9 +909,9 @@ public void setIncrement (int value) {
     checkWidget ();
     if (value < 1) return;
     auto hHeap = OS.GetProcessHeap ();
-    auto count = OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, 0, cast(UDACCEL*)null);
+    auto count = OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, 0, 0);
     auto udaccels = cast(UDACCEL*) OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, UDACCEL.sizeof * count);
-    OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, count, udaccels);
+    OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, count, cast(LPARAM)udaccels);
     int first = -1;
     UDACCEL udaccel;
     for (int i = 0; i < count; i++) {
@@ -921,7 +921,7 @@ public void setIncrement (int value) {
         udaccel.nInc  =  udaccel.nInc * value / first;
         OS.MoveMemory (offset, &udaccel, UDACCEL.sizeof);
     }
-    OS.SendMessage (hwndUpDown, OS.UDM_SETACCEL, count, udaccels);
+    OS.SendMessage (hwndUpDown, OS.UDM_SETACCEL, count, cast(LPARAM)udaccels);
     OS.HeapFree (hHeap, 0, udaccels);
 }
 
@@ -941,7 +941,7 @@ public void setIncrement (int value) {
 public void setMaximum (int value) {
     checkWidget ();
     int min;
-    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, null);
+    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, 0);
     if (value <= min) return;
     .LRESULT pos;
     static if (OS.IsWinCE) {
@@ -969,7 +969,7 @@ public void setMaximum (int value) {
 public void setMinimum (int value) {
     checkWidget ();
     int max;
-    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, null, &max);
+    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, 0, cast(LPARAM)&max);
     if (value >= max) return;
     .LRESULT pos;
     static if (OS.IsWinCE) {
@@ -1015,7 +1015,7 @@ public void setPageIncrement (int value) {
 public void setSelection (int value) {
     checkWidget ();
     int max, min;
-    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, &max);
+    OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, cast(LPARAM)&max);
     value = Math.min (Math.max (min, value), max );
     setSelection (value, true, true, false);
 }
@@ -1165,7 +1165,7 @@ String verifyText (String string, int start, int end, Event keyEvent) {
     }
     if (string.length > 0) {
         int min;
-        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, null);
+        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, 0);
         if (min < 0 && string.charAt (0) is '-') index++;
     }
     while (index < string.length ) {
@@ -1313,25 +1313,25 @@ LRESULT wmClipboard (HWND hwndText, int msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
         case OS.WM_CLEAR:
         case OS.WM_CUT:
-            OS.SendMessage (hwndText, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             if (start !is end) {
                 newText = "";
                 call = true;
             }
             break;
         case OS.WM_PASTE:
-            OS.SendMessage (hwndText, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             newText = getClipboardText ();
             break;
         case OS.EM_UNDO:
         case OS.WM_UNDO:
             if (OS.SendMessage (hwndText, OS.EM_CANUNDO, 0, 0) !is 0) {
                 ignoreModify = true;
-                OS.SendMessage (hwndText, OS.EM_GETSEL, &start, &end);
+                OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
                 OS.CallWindowProc (EditProc, hwndText, msg, wParam, lParam);
                 int length_ = OS.GetWindowTextLength (hwndText);
                 int newStart, newEnd;
-                OS.SendMessage (hwndText, OS.EM_GETSEL, &newStart, &newEnd);
+                OS.SendMessage (hwndText, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                 if (length_ !is 0 && newStart !is newEnd ) {
                     TCHAR[] buffer = NewTCHARs (getCodePage (), length_ + 1);
                     OS.GetWindowText (hwndText, buffer.ptr, length_ + 1);
@@ -1363,7 +1363,7 @@ LRESULT wmClipboard (HWND hwndText, int msg, WPARAM wParam, LPARAM lParam) {
                 OS.HeapFree (hHeap, 0, pszText);
                 return new LRESULT (code);
             } else {
-                OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(void*)buffer.ptr);
+                OS.SendMessage (hwndText, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer.ptr);
                 return LRESULT.ZERO;
             }
         }
@@ -1401,7 +1401,7 @@ override LRESULT wmKeyDown (HWND hwnd, WPARAM wParam, LPARAM lParam) {
 
     /* Increment the value */
     UDACCEL udaccel;
-    OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, 1, &udaccel);
+    OS.SendMessage (hwndUpDown, OS.UDM_GETACCEL, 1, cast(LPARAM)&udaccel);
     int delta = 0;
     switch (wParam) {
         case OS.VK_UP: delta = udaccel.nInc; break;
@@ -1422,7 +1422,7 @@ override LRESULT wmKeyDown (HWND hwnd, WPARAM wParam, LPARAM lParam) {
         }
         auto newValue = value + delta;
         int max, min;
-        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, &max);
+        OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, cast(LPARAM)&max);
         if ((style & SWT.WRAP) !is 0) {
             if (newValue < min ) newValue = max;
             if (newValue > max ) newValue = min;
@@ -1462,7 +1462,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
             //OS.MoveMemory (lpnmud, lParam, NMUPDOWN.sizeof);
             int value = lpnmud.iPos + lpnmud.iDelta;
             int max, min;
-            OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, &min, &max);
+            OS.SendMessage (hwndUpDown , OS.UDM_GETRANGE32, cast(WPARAM)&min, cast(LPARAM)&max);
             if ((style & SWT.WRAP) !is 0) {
                 if (value < min ) value = max ;
                 if (value > max ) value = min ;

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TabFolder.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TabFolder.d
@@ -221,16 +221,16 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
     checkWidget ();
     Point size = super.computeSize (wHint, hHint, changed);
     RECT insetRect, itemRect;
-    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, &insetRect);
+    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, cast(LPARAM)&insetRect);
     int width = insetRect.left - insetRect.right;
     auto count = OS.SendMessage (handle, OS.TCM_GETITEMCOUNT, 0, 0);
     if (count !is 0) {
-        OS.SendMessage (handle, OS.TCM_GETITEMRECT, count - 1, &itemRect);
+        OS.SendMessage (handle, OS.TCM_GETITEMRECT, count - 1, cast(LPARAM)&itemRect);
         width = Math.max (width, itemRect.right - insetRect.right);
     }
     RECT rect;
     OS.SetRect (&rect, 0, 0, width, size.y);
-    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 1, &rect);
+    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 1, cast(LPARAM)&rect);
     int border = getBorderWidth ();
     rect.left -= border;  rect.right += border;
     width = rect.right - rect.left;
@@ -242,7 +242,7 @@ override public Rectangle computeTrim (int x, int y, int width, int height) {
     checkWidget ();
     RECT rect;
     OS.SetRect (&rect, x, y, x + width, y + height);
-    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 1, &rect);
+    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 1, cast(LPARAM)&rect);
     int border = getBorderWidth ();
     rect.left -= border;  rect.right += border;
     rect.top -= border;  rect.bottom += border;
@@ -260,7 +260,7 @@ void createItem (TabItem item, int index) {
         items = newItems;
     }
     TCITEM tcItem;
-    if (OS.SendMessage (handle, OS.TCM_INSERTITEM, index, &tcItem) is -1) {
+    if (OS.SendMessage (handle, OS.TCM_INSERTITEM, index, cast(LPARAM)&tcItem) is -1) {
         error (SWT.ERROR_ITEM_NOT_ADDED);
     }
     System.arraycopy (items, index, items, index + 1, count - index);
@@ -351,7 +351,7 @@ override public Rectangle getClientArea () {
     forceResize ();
     RECT rect;
     OS.GetClientRect (handle, &rect);
-    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, &rect);
+    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, cast(LPARAM)&rect);
     int width = rect.right - rect.left;
     int height = rect.bottom - rect.top;
     return new Rectangle (rect.left, rect.top, width, height);
@@ -403,7 +403,7 @@ public TabItem getItem (Point point) {
     TCHITTESTINFO pinfo;
     pinfo.pt.x = point.x;
     pinfo.pt.y = point.y;
-    auto index = OS.SendMessage (handle, OS.TCM_HITTEST, 0, &pinfo);
+    auto index = OS.SendMessage (handle, OS.TCM_HITTEST, 0, cast(LPARAM)&pinfo);
     if (index is -1) return null;
     return items [index];
 }
@@ -493,7 +493,7 @@ int imageIndex (Image image) {
         imageList = display.getImageList (style & SWT.RIGHT_TO_LEFT, bounds.width, bounds.height);
         int index = imageList.add (image);
         auto hImageList = imageList.getHandle ();
-        OS.SendMessage (handle, OS.TCM_SETIMAGELIST, 0, hImageList);
+        OS.SendMessage (handle, OS.TCM_SETIMAGELIST, 0, cast(LPARAM)hImageList);
         return index;
     }
     int index = imageList.indexOf (image);
@@ -853,10 +853,10 @@ override LRESULT WM_MOUSELEAVE (WPARAM wParam, LPARAM lParam) {
         TOOLINFO lpti;
         lpti.cbSize = OS.TOOLINFO_sizeof;
         auto hwndToolTip = cast(HWND) OS.SendMessage (handle, OS.TCM_GETTOOLTIPS, 0, 0);
-        if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+        if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
             if ((lpti.uFlags & OS.TTF_IDISHWND) is 0) {
-                OS.SendMessage (hwndToolTip, OS.TTM_DELTOOL, 0, &lpti);
-                OS.SendMessage (hwndToolTip, OS.TTM_ADDTOOL, 0, &lpti);
+                OS.SendMessage (hwndToolTip, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
+                OS.SendMessage (hwndToolTip, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
             }
         }
     }
@@ -980,7 +980,7 @@ override LRESULT WM_WINDOWPOSCHANGING (WPARAM wParam, LPARAM lParam) {
     }
     RECT rect;
     OS.SetRect (&rect, 0, 0, lpwp.cx, lpwp.cy);
-    OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, &rect);
+    OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, cast(LPARAM)&rect);
     int newWidth = rect.right - rect.left;
     int newHeight = rect.bottom - rect.top;
     OS.GetClientRect (handle, &rect);
@@ -990,7 +990,7 @@ override LRESULT WM_WINDOWPOSCHANGING (WPARAM wParam, LPARAM lParam) {
         return result;
     }
     RECT inset;
-    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, &inset);
+    OS.SendMessage (handle, OS.TCM_ADJUSTRECT, 0, cast(LPARAM)&inset);
     int marginX = -inset.right, marginY = -inset.bottom;
     if (newWidth !is oldWidth) {
         int left = oldWidth;

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TabItem.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TabItem.d
@@ -150,7 +150,7 @@ void _setText (int index, String string) {
     TCITEM tcItem;
     tcItem.mask = OS.TCIF_TEXT;
     tcItem.pszText = pszText;
-    OS.SendMessage (hwnd, OS.TCM_SETITEM, index, &tcItem);
+    OS.SendMessage (hwnd, OS.TCM_SETITEM, index, cast(LPARAM)&tcItem);
     OS.HeapFree (hHeap, 0, pszText);
 }
 
@@ -198,7 +198,7 @@ public Rectangle getBounds() {
     int index = parent.indexOf(this);
     if (index is -1) return new Rectangle (0, 0, 0, 0);
     RECT itemRect;
-    OS.SendMessage (parent.handle, OS.TCM_GETITEMRECT, index, &itemRect);
+    OS.SendMessage (parent.handle, OS.TCM_GETITEMRECT, index, cast(LPARAM)&itemRect);
     return new Rectangle(itemRect.left, itemRect.top, itemRect.right - itemRect.left, itemRect.bottom - itemRect.top);
 }
 
@@ -309,7 +309,7 @@ override public void setImage (Image image) {
     TCITEM tcItem;
     tcItem.mask = OS.TCIF_IMAGE;
     tcItem.iImage = parent.imageIndex (image);
-    OS.SendMessage (hwnd, OS.TCM_SETITEM, index, &tcItem);
+    OS.SendMessage (hwnd, OS.TCM_SETITEM, index, cast(LPARAM)&tcItem);
 }
 /**
  * Sets the receiver's text.  The string may include

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Table.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Table.d
@@ -506,17 +506,17 @@ LRESULT CDDS_ITEMPOSTPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
                                     rect.left = OS.LVIR_BOUNDS;
                                     bool oldIgnore = ignoreCustomDraw;
                                     ignoreCustomDraw = true;
-                                    OS.SendMessage (handle, OS. LVM_GETITEMRECT, nmcd.nmcd.dwItemSpec, &rect);
+                                    OS.SendMessage (handle, OS. LVM_GETITEMRECT, nmcd.nmcd.dwItemSpec, cast(LPARAM)&rect);
                                     auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
                                     auto index = OS.SendMessage (hwndHeader, OS.HDM_ORDERTOINDEX, 0, 0);
                                     RECT itemRect;
                                     if (index is 0) {
                                         itemRect.left = OS.LVIR_LABEL;
-                                        OS.SendMessage (handle, OS. LVM_GETITEMRECT, index, &itemRect);
+                                        OS.SendMessage (handle, OS. LVM_GETITEMRECT, index, cast(LPARAM)&itemRect);
                                     } else {
                                         itemRect.top = cast(int)/*64bit*/index;
                                         itemRect.left = OS.LVIR_ICON;
-                                        OS.SendMessage (handle, OS. LVM_GETSUBITEMRECT, nmcd.nmcd.dwItemSpec, &itemRect);
+                                        OS.SendMessage (handle, OS. LVM_GETSUBITEMRECT, nmcd.nmcd.dwItemSpec, cast(LPARAM)&itemRect);
                                     }
                                     ignoreCustomDraw = oldIgnore;
                                     rect.left = itemRect.left;
@@ -553,7 +553,7 @@ LRESULT CDDS_ITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                     if ((dwExStyle & OS.LVS_EX_FULLROWSELECT) is 0) {
                         if ((nmcd.nmcd.uItemState & OS.CDIS_FOCUS) !is 0) {
                             nmcd.nmcd.uItemState &= ~OS.CDIS_FOCUS;
-                            OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+                            OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
                         }
                     }
                 }
@@ -712,7 +712,7 @@ LRESULT CDDS_PREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                                     RECT columnRect, headerRect;
                                     OS.GetClientRect (handle, &columnRect);
                                     auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-                                    if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect) !is 0) {
+                                    if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect) !is 0) {
                                         OS.MapWindowPoints (hwndHeader, handle, cast(POINT*) &headerRect, 2);
                                         columnRect.left = headerRect.left;
                                         columnRect.right = headerRect.right;
@@ -842,7 +842,7 @@ LRESULT CDDS_SUBITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam
                 lvItem.mask = OS.LVIF_STATE;
                 lvItem.stateMask = OS.LVIS_SELECTED;
                 lvItem.iItem = cast(int)/*64bit*/nmcd.nmcd.dwItemSpec;
-                auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, &lvItem);
+                auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, cast(LPARAM)&lvItem);
                 if ((result !is 0 && (lvItem.state & OS.LVIS_SELECTED) !is 0)) {
                     int clrSelection = -1;
                     if (nmcd.iSubItem is 0) {
@@ -906,7 +906,7 @@ LRESULT CDDS_SUBITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam
                 } else {
                     nmcd.clrTextBk = selectionForeground !is -1 ? OS.CLR_NONE : clrTextBk;
                 }
-                OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+                OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
             }
             code |= OS.CDRF_NEWFONT;
         }
@@ -949,7 +949,7 @@ LRESULT CDDS_SUBITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam
             nmcd.clrTextBk = OS.GetSysColor (OS.COLOR_3DFACE);
         }
         nmcd.nmcd.uItemState &= ~OS.CDIS_SELECTED;
-        OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+        OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
         code |= OS.CDRF_NEWFONT;
     }
     return new LRESULT (code);
@@ -1040,7 +1040,7 @@ public void clear (int index) {
             lvItem.mask = OS.LVIF_TEXT | OS.LVIF_INDENT;
             lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
             lvItem.iItem = index;
-            OS.SendMessage (handle, OS.LVM_SETITEM, 0, &lvItem);
+            OS.SendMessage (handle, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
             item.cached = false;
         }
         if (currentItem is null && drawCount is 0 && OS.IsWindowVisible (handle)) {
@@ -1110,7 +1110,7 @@ public void clear (int start, int end) {
                         lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
                     //}
                     lvItem.iItem = i;
-                    OS.SendMessage (handle, OS.LVM_SETITEM, 0, &lvItem);
+                    OS.SendMessage (handle, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
                     item.cached = false;
                 }
             }
@@ -1185,7 +1185,7 @@ public void clear (int [] indices) {
                     lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
                 //}
                 lvItem.iItem = i;
-                OS.SendMessage (handle, OS.LVM_SETITEM, 0, &lvItem);
+                OS.SendMessage (handle, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
                 item.cached = false;
             }
             if (currentItem is null && drawCount is 0 && OS.IsWindowVisible (handle)) {
@@ -1242,7 +1242,7 @@ public void clearAll () {
                     lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
                 //}
                 lvItem.iItem = i;
-                OS.SendMessage (handle, OS.LVM_SETITEM, 0, &lvItem);
+                OS.SendMessage (handle, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
                 item.cached = false;
             }
         }
@@ -1380,7 +1380,7 @@ override void createHandle () {
     * create.
     */
     auto hFont = OS.GetStockObject (OS.SYSTEM_FONT);
-    OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+    OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
 
     /*
     * Bug in Windows.  When the first column is inserted
@@ -1394,7 +1394,7 @@ override void createHandle () {
     auto hHeap = OS.GetProcessHeap ();
     auto pszText = cast(TCHAR*) OS.HeapAlloc (hHeap, OS.HEAP_ZERO_MEMORY, TCHAR.sizeof);
     lvColumn.pszText = pszText;
-    OS.SendMessage (handle, OS.LVM_INSERTCOLUMN, 0, &lvColumn);
+    OS.SendMessage (handle, OS.LVM_INSERTCOLUMN, 0, cast(LPARAM)&lvColumn);
     OS.HeapFree (hHeap, 0, pszText);
 
     /* Set the extended style bits */
@@ -1541,8 +1541,8 @@ void createItem (TableColumn column, int index) {
         if (columnCount > 1) {
             LVCOLUMN lvColumn;
             lvColumn.mask = OS.LVCF_WIDTH;
-            OS.SendMessage (handle, OS.LVM_INSERTCOLUMN, 1, &lvColumn);
-            OS.SendMessage (handle, OS.LVM_GETCOLUMN, 1, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_INSERTCOLUMN, 1, cast(LPARAM)&lvColumn);
+            OS.SendMessage (handle, OS.LVM_GETCOLUMN, 1, cast(LPARAM)&lvColumn);
             int width = lvColumn.cx;
             int cchTextMax = 1024;
             auto hHeap = OS.GetProcessHeap ();
@@ -1551,16 +1551,16 @@ void createItem (TableColumn column, int index) {
             lvColumn.mask = OS.LVCF_TEXT | OS.LVCF_IMAGE | OS.LVCF_WIDTH | OS.LVCF_FMT;
             lvColumn.pszText = pszText;
             lvColumn.cchTextMax = cchTextMax;
-            OS.SendMessage (handle, OS.LVM_GETCOLUMN, 0, &lvColumn);
-            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 1, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_GETCOLUMN, 0, cast(LPARAM)&lvColumn);
+            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 1, cast(LPARAM)&lvColumn);
             lvColumn.fmt = OS.LVCFMT_IMAGE;
             lvColumn.cx = width;
             lvColumn.iImage = OS.I_IMAGENONE;
             lvColumn.pszText = null, lvColumn.cchTextMax = 0;
-            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, cast(LPARAM)&lvColumn);
             lvColumn.mask = OS.LVCF_FMT;
             lvColumn.fmt = OS.LVCFMT_LEFT;
-            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, cast(LPARAM)&lvColumn);
             if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
         } else {
             OS.SendMessage (handle, OS.LVM_SETCOLUMNWIDTH, 0, 0);
@@ -1583,7 +1583,7 @@ void createItem (TableColumn column, int index) {
             lvItem.iImage = OS.I_IMAGECALLBACK;
             for (int i=0; i<itemCount; i++) {
                 lvItem.iItem = i;
-                OS.SendMessage (handle, OS.LVM_SETITEM, 0, &lvItem);
+                OS.SendMessage (handle, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
             }
         }
     } else {
@@ -1593,7 +1593,7 @@ void createItem (TableColumn column, int index) {
         LVCOLUMN lvColumn;
         lvColumn.mask = OS.LVCF_WIDTH | OS.LVCF_FMT;
         lvColumn.fmt = fmt;
-        OS.SendMessage (handle, OS.LVM_INSERTCOLUMN, index, &lvColumn);
+        OS.SendMessage (handle, OS.LVM_INSERTCOLUMN, index, cast(LPARAM)&lvColumn);
     }
     ignoreColumnResize = false;
 
@@ -1601,7 +1601,7 @@ void createItem (TableColumn column, int index) {
     if (headerToolTipHandle !is null) {
         RECT rect;
         auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &rect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&rect) !is 0) {
             TOOLINFO lpti;
             lpti.cbSize = OS.TOOLINFO_sizeof;
             lpti.uFlags = OS.TTF_SUBCLASS;
@@ -1612,7 +1612,7 @@ void createItem (TableColumn column, int index) {
             lpti.rect.right = rect.right;
             lpti.rect.bottom = rect.bottom;
             lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
-            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, &lpti);
+            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
         }
     }
 }
@@ -1652,7 +1652,7 @@ void createItem (TableItem item, int index) {
     /* Insert the item */
     setDeferResize (true);
     ignoreSelect = ignoreShrink = true;
-    auto result = OS.SendMessage (handle, OS.LVM_INSERTITEM, 0, &lvItem);
+    auto result = OS.SendMessage (handle, OS.LVM_INSERTITEM, 0, cast(LPARAM)&lvItem);
     ignoreSelect = ignoreShrink = false;
     if (result is -1) error (SWT.ERROR_ITEM_NOT_ADDED);
     System.arraycopy (items, index, items, index + 1, count - index);
@@ -1708,7 +1708,7 @@ public void deselect (int [] indices) {
         */
         if (indices [i] >= 0) {
             ignoreSelect = true;
-            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, indices [i], &lvItem);
+            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, indices [i], cast(LPARAM)&lvItem);
             ignoreSelect = false;
         }
     }
@@ -1736,7 +1736,7 @@ public void deselect (int index) {
     LVITEM lvItem;
     lvItem.stateMask = OS.LVIS_SELECTED;
     ignoreSelect = true;
-    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, index, &lvItem);
+    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, index, cast(LPARAM)&lvItem);
     ignoreSelect = false;
 }
 
@@ -1770,7 +1770,7 @@ public void deselect (int start, int end) {
         start = Math.max (0, start);
         for (int i=start; i<=end; i++) {
             ignoreSelect = true;
-            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, i, &lvItem);
+            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, i, cast(LPARAM)&lvItem);
             ignoreSelect = false;
         }
     }
@@ -1790,7 +1790,7 @@ public void deselectAll () {
     lvItem.mask = OS.LVIF_STATE;
     lvItem.stateMask = OS.LVIS_SELECTED;
     ignoreSelect = true;
-    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, -1, &lvItem);
+    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, -1, cast(LPARAM)&lvItem);
     ignoreSelect = false;
 }
 
@@ -1810,7 +1810,7 @@ void destroyItem (TableColumn column) {
     }
     int orderIndex = 0;
     int [] oldOrder = new int [columnCount];
-    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, oldOrder.ptr);
+    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, cast(LPARAM)oldOrder.ptr);
     while (orderIndex < columnCount) {
         if (oldOrder [orderIndex] is index) break;
         orderIndex++;
@@ -1829,10 +1829,10 @@ void destroyItem (TableColumn column) {
             lvColumn.mask = OS.LVCF_TEXT | OS.LVCF_IMAGE | OS.LVCF_WIDTH | OS.LVCF_FMT;
             lvColumn.pszText = pszText;
             lvColumn.cchTextMax = cchTextMax;
-            OS.SendMessage (handle, OS.LVM_GETCOLUMN, 1, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_GETCOLUMN, 1, cast(LPARAM)&lvColumn);
             lvColumn.fmt &= ~(OS.LVCFMT_CENTER | OS.LVCFMT_RIGHT);
             lvColumn.fmt |= OS.LVCFMT_LEFT;
-            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, cast(LPARAM)&lvColumn);
             if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
         } else {
             auto hHeap = OS.GetProcessHeap ();
@@ -1842,14 +1842,14 @@ void destroyItem (TableColumn column) {
             lvColumn.pszText = pszText;
             lvColumn.iImage = OS.I_IMAGENONE;
             lvColumn.fmt = OS.LVCFMT_LEFT;
-            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, &lvColumn);
+            OS.SendMessage (handle, OS.LVM_SETCOLUMN, 0, cast(LPARAM)&lvColumn);
             if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
             if (OS.COMCTL32_MAJOR >= 6) {
                 HDITEM hdItem;
                 hdItem.mask = OS.HDI_FORMAT;
                 hdItem.fmt = OS.HDF_LEFT;
                 auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-                OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+                OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
             }
         }
         /*
@@ -1871,7 +1871,7 @@ void destroyItem (TableColumn column) {
             auto itemCount = OS.SendMessage (handle, OS.LVM_GETITEMCOUNT, 0, 0);
             for (int i=0; i<itemCount; i++) {
                 lvItem.iItem = i;
-                OS.SendMessage (handle, OS.LVM_SETITEM, 0, &lvItem);
+                OS.SendMessage (handle, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
             }
         }
     }
@@ -1964,14 +1964,14 @@ void destroyItem (TableColumn column) {
                 newOrder [count++] = newIndex;
             }
         }
-        OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, oldOrder.ptr);
+        OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, cast(LPARAM)oldOrder.ptr);
         int j = 0;
         while (j < newOrder.length) {
             if (oldOrder [j] !is newOrder [j]) break;
             j++;
         }
         if (j !is newOrder.length) {
-            OS.SendMessage (handle, OS.LVM_SETCOLUMNORDERARRAY, newOrder.length, newOrder.ptr);
+            OS.SendMessage (handle, OS.LVM_SETCOLUMNORDERARRAY, newOrder.length, cast(LPARAM)newOrder.ptr);
             /*
             * Bug in Windows.  When LVM_SETCOLUMNORDERARRAY is used to change
             * the column order, the header redraws correctly but the table does
@@ -1997,7 +1997,7 @@ void destroyItem (TableColumn column) {
         lpti.cbSize = OS.TOOLINFO_sizeof;
         lpti.uId = column.id;
         lpti.hwnd = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-        OS.SendMessage (headerToolTipHandle, OS.TTM_DELTOOL, 0, &lpti);
+        OS.SendMessage (headerToolTipHandle, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
     }
 }
 
@@ -2088,12 +2088,12 @@ void fixItemHeight (bool fixScroll) {
     OS.GetWindowRect (hwndHeader, &rect);
     int height = rect.bottom - rect.top - 1;
     auto hImageList = OS.ImageList_Create (1, height, 0, 0, 0);
-    OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
+    OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, cast(LPARAM)hImageList);
     fixCheckboxImageList (false);
     OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, 0);
     if (headerImageList !is null) {
         auto hHeaderImageList = headerImageList.getHandle ();
-        OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hHeaderImageList);
+        OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, cast(LPARAM)hHeaderImageList);
     }
     OS.ImageList_Destroy (hImageList);
     if (fixScroll && topIndex !is 0) {
@@ -2186,7 +2186,7 @@ public int[] getColumnOrder () {
     checkWidget ();
     if (columnCount is 0) return new int [0];
     int [] order = new int [columnCount];
-    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, order.ptr);
+    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, cast(LPARAM)order.ptr);
     return order;
 }
 
@@ -2343,16 +2343,16 @@ public TableItem getItem (Point point) {
     pinfo.pt.y = point.y;
     if ((style & SWT.FULL_SELECTION) is 0) {
         if (hooks (SWT.MeasureItem)) {
-            OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, &pinfo);
+            OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, cast(LPARAM)&pinfo);
             if (pinfo.iItem is -1) {
                 RECT rect;
                 rect.left = OS.LVIR_ICON;
                 ignoreCustomDraw = true;
-                auto code = OS.SendMessage (handle, OS.LVM_GETITEMRECT, 0, &rect);
+                auto code = OS.SendMessage (handle, OS.LVM_GETITEMRECT, 0, cast(LPARAM)&rect);
                 ignoreCustomDraw = false;
                 if (code !is 0) {
                     pinfo.pt.x = rect.left;
-                    OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, &pinfo);
+                    OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, cast(LPARAM)&pinfo);
                 }
             }
             if (pinfo.iItem !is -1 && pinfo.iSubItem is 0) {
@@ -2363,7 +2363,7 @@ public TableItem getItem (Point point) {
             return null;
         }
     }
-    OS.SendMessage (handle, OS.LVM_HITTEST, 0, &pinfo);
+    OS.SendMessage (handle, OS.LVM_HITTEST, 0, cast(LPARAM)&pinfo);
     if (pinfo.iItem !is -1) {
         /*
         * Bug in Windows.  When the point that is used by
@@ -2710,11 +2710,11 @@ int imageIndex (Image image, int column) {
             setRedraw (false);
             setTopIndex (0);
         }
-        OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
+        OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, cast(LPARAM)hImageList);
         if (headerImageList !is null) {
             auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
             auto hHeaderImageList = headerImageList.getHandle ();
-            OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hHeaderImageList);
+            OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, cast(LPARAM)hHeaderImageList);
         }
         fixCheckboxImageList (false);
         if (itemHeight !is -1) setItemHeight (false);
@@ -2738,7 +2738,7 @@ int imageIndexHeader (Image image) {
         if (index is -1) index = headerImageList.add (image);
         auto hImageList = headerImageList.getHandle ();
         auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-        OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hImageList);
+        OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, cast(LPARAM)hImageList);
         return index;
     }
     int index = headerImageList.indexOf (image);
@@ -2838,7 +2838,7 @@ public bool isSelected (int index) {
     lvItem.mask = OS.LVIF_STATE;
     lvItem.stateMask = OS.LVIS_SELECTED;
     lvItem.iItem = index;
-    auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, &lvItem);
+    auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, cast(LPARAM)&lvItem);
     return (result !is 0) && ((lvItem.state & OS.LVIS_SELECTED) !is 0);
 }
 
@@ -3167,7 +3167,7 @@ public void select (int [] indices) {
         */
         if (indices [i] >= 0) {
             ignoreSelect = true;
-            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, indices [i], &lvItem);
+            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, indices [i], cast(LPARAM)&lvItem);
             ignoreSelect = false;
         }
     }
@@ -3196,7 +3196,7 @@ public void select (int index) {
     lvItem.state = OS.LVIS_SELECTED;
     lvItem.stateMask = OS.LVIS_SELECTED;
     ignoreSelect = true;
-    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, index, &lvItem);
+    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, index, cast(LPARAM)&lvItem);
     ignoreSelect = false;
 }
 
@@ -3242,7 +3242,7 @@ public void select (int start, int end) {
         lvItem.stateMask = OS.LVIS_SELECTED;
         for (int i=start; i<=end; i++) {
             ignoreSelect = true;
-            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, i, &lvItem);
+            OS.SendMessage (handle, OS.LVM_SETITEMSTATE, i, cast(LPARAM)&lvItem);
             ignoreSelect = false;
         }
     }
@@ -3267,7 +3267,7 @@ public void selectAll () {
     lvItem.state = OS.LVIS_SELECTED;
     lvItem.stateMask = OS.LVIS_SELECTED;
     ignoreSelect = true;
-    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, -1, &lvItem);
+    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, -1, cast(LPARAM)&lvItem);
     ignoreSelect = false;
 }
 
@@ -3296,7 +3296,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, int lParam, Event
     lvItem.mask = OS.LVIF_STATE;
     lvItem.stateMask = OS.LVIS_SELECTED;
     lvItem.iItem = cast(int)/*64bit*/nmcd.nmcd.dwItemSpec;
-    auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, &lvItem);
+    auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, cast(LPARAM)&lvItem);
     bool selected = (result !is 0 && (lvItem.state & OS.LVIS_SELECTED) !is 0);
     GCData data = new GCData ();
     data.device = display;
@@ -3392,12 +3392,12 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, int lParam, Event
                 selectionForeground = clrSelectionText;
             }
             nmcd.nmcd.uItemState &= ~OS.CDIS_SELECTED;
-            OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+            OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
         }
     } else {
         if (ignoreDrawSelection) {
             nmcd.nmcd.uItemState |= OS.CDIS_SELECTED;
-            OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+            OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
         }
     }
 
@@ -3419,7 +3419,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, int lParam, Event
             }
             if (!ignoreDrawFocus) {
                 nmcd.nmcd.uItemState &= ~OS.CDIS_FOCUS;
-                OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+                OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
                 focusRect = new RECT;
                 *focusRect = textRect;
             }
@@ -3435,7 +3435,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, int lParam, Event
                     auto count = OS.SendMessage (hwndHeader, OS.HDM_GETITEMCOUNT, 0, 0);
                     auto index = OS.SendMessage (hwndHeader, OS.HDM_ORDERTOINDEX, count - 1, 0);
                     RECT headerRect;
-                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
                     OS.MapWindowPoints (hwndHeader, handle, cast(POINT*) &headerRect, 2);
                     rect.left = 0;
                     rect.right = headerRect.right;
@@ -3457,7 +3457,7 @@ void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, int lParam, Event
     }
     if (focused && ignoreDrawFocus) {
         nmcd.nmcd.uItemState &= ~OS.CDIS_FOCUS;
-        OS.MoveMemory (lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
+        OS.MoveMemory (cast(LPVOID)lParam, nmcd, OS.NMLVCUSTOMDRAW_sizeof);
     }
     if (ignoreDrawForeground) {
         RECT clipRect = item.getBounds (cast(int)/*64bit*/nmcd.nmcd.dwItemSpec, nmcd.iSubItem, true, true, true, false, hDC);
@@ -3552,21 +3552,21 @@ LRESULT sendMouseDownEvent (int type, int button, int msg, WPARAM wParam, LPARAM
     LVHITTESTINFO pinfo;
     pinfo.pt.x = OS.GET_X_LPARAM (lParam);
     pinfo.pt.y = OS.GET_Y_LPARAM (lParam);
-    OS.SendMessage (handle, OS.LVM_HITTEST, 0, &pinfo);
+    OS.SendMessage (handle, OS.LVM_HITTEST, 0, cast(LPARAM)&pinfo);
     if ((style & SWT.FULL_SELECTION) is 0) {
         if (hooks (SWT.MeasureItem)) {
-            OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, &pinfo);
+            OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, cast(LPARAM)&pinfo);
             if (pinfo.iItem is -1) {
                 auto count = OS.SendMessage (handle, OS.LVM_GETITEMCOUNT, 0, 0);
                 if (count !is 0) {
                     RECT rect;
                     rect.left = OS.LVIR_ICON;
                     ignoreCustomDraw = true;
-                    auto code = OS.SendMessage (handle, OS.LVM_GETITEMRECT, 0, &rect);
+                    auto code = OS.SendMessage (handle, OS.LVM_GETITEMRECT, 0, cast(LPARAM)&rect);
                     ignoreCustomDraw = false;
                     if (code !is 0) {
                         pinfo.pt.x = rect.left;
-                        OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, &pinfo);
+                        OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, cast(LPARAM)&pinfo);
                         pinfo.flags &= ~(OS.LVHT_ONITEMICON | OS.LVHT_ONITEMLABEL);
                     }
                 }
@@ -3618,7 +3618,7 @@ LRESULT sendMouseDownEvent (int type, int button, int msg, WPARAM wParam, LPARAM
         lvItem.mask = OS.LVIF_STATE;
         lvItem.stateMask = OS.LVIS_SELECTED;
         lvItem.iItem = pinfo.iItem;
-        OS.SendMessage (handle, OS.LVM_GETITEM, 0, &lvItem);
+        OS.SendMessage (handle, OS.LVM_GETITEM, 0, cast(LPARAM)&lvItem);
         if ((lvItem.state & OS.LVIS_SELECTED) !is 0) {
             forceSelect = true;
         }
@@ -3705,7 +3705,7 @@ void sendPaintItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd) {
     lvItem.mask = OS.LVIF_STATE;
     lvItem.stateMask = OS.LVIS_SELECTED;
     lvItem.iItem = cast(int)/*64bit*/nmcd.nmcd.dwItemSpec;
-    auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, &lvItem);
+    auto result = OS.SendMessage (handle, OS.LVM_GETITEM, 0, cast(LPARAM)&lvItem);
     bool selected = result !is 0 && (lvItem.state & OS.LVIS_SELECTED) !is 0;
     bool drawSelected = false, drawBackground = false, drawHot = false;
     if (nmcd.iSubItem is 0 || (style & SWT.FULL_SELECTION) !is 0) {
@@ -3992,7 +3992,7 @@ public void setColumnOrder (int [] order) {
     }
     if (order.length !is columnCount) error (SWT.ERROR_INVALID_ARGUMENT);
     int [] oldOrder = new int [columnCount];
-    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, oldOrder.ptr);
+    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, cast(LPARAM)oldOrder.ptr);
     bool reorder = false;
     bool [] seen = new bool [columnCount];
     for (int i=0; i<order.length; i++) {
@@ -4006,9 +4006,9 @@ public void setColumnOrder (int [] order) {
         RECT [] oldRects = new RECT [columnCount];
         for (int i=0; i<columnCount; i++) {
             //oldRects [i] = new RECT ();
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &oldRects [i]);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&oldRects [i]);
         }
-        OS.SendMessage (handle, OS.LVM_SETCOLUMNORDERARRAY, order.length, order.ptr);
+        OS.SendMessage (handle, OS.LVM_SETCOLUMNORDERARRAY, order.length, cast(LPARAM)order.ptr);
         /*
         * Bug in Windows.  When LVM_SETCOLUMNORDERARRAY is used to change
         * the column order, the header redraws correctly but the table does
@@ -4021,7 +4021,7 @@ public void setColumnOrder (int [] order) {
         for (int i=0; i<columnCount; i++) {
             TableColumn column = newColumns [i];
             if (!column.isDisposed ()) {
-                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &newRect);
+                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&newRect);
                 if (newRect.left !is oldRects [i].left) {
                     column.updateToolTip (i);
                     column.sendEvent (SWT.Move);
@@ -4182,7 +4182,7 @@ void setCheckboxImageList (int width, int height, bool fixScroll) {
         setTopIndex (0);
     }
     auto hOldStateList = cast(HANDLE) OS.SendMessage (handle, OS.LVM_GETIMAGELIST, OS.LVSIL_STATE, 0);
-    OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_STATE, hStateList);
+    OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_STATE, cast(LPARAM)hStateList);
     if (hOldStateList !is null) OS.ImageList_Destroy (hOldStateList);
     /*
     * Bug in Windows.  Setting the LVSIL_STATE state image list
@@ -4192,7 +4192,7 @@ void setCheckboxImageList (int width, int height, bool fixScroll) {
     */
     if (!OS.IsWinCE && OS.WIN32_VERSION >= OS.VERSION (6, 0)) {
         auto hImageList = cast(HANDLE) OS.SendMessage (handle, OS.LVM_GETIMAGELIST, OS.LVSIL_SMALL, 0);
-        OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
+        OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, cast(LPARAM)hImageList);
     }
     if (fixScroll && topIndex !is 0) {
         setTopIndex (topIndex);
@@ -4211,7 +4211,7 @@ void setFocusIndex (int index) {
     lvItem.state = OS.LVIS_FOCUSED;
     lvItem.stateMask = OS.LVIS_FOCUSED;
     ignoreSelect = true;
-    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, index, &lvItem);
+    OS.SendMessage (handle, OS.LVM_SETITEMSTATE, index, cast(LPARAM)&lvItem);
     ignoreSelect = false;
     OS.SendMessage (handle, OS.LVM_SETSELECTIONMARK, 0, index);
 }
@@ -4411,7 +4411,7 @@ void setItemHeight (bool fixScroll) {
         * height.
         */
         auto hFont = cast(HFONT) OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
-        OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+        OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
     } else {
         /*
         * Feature in Windows.  Window has no API to set the item
@@ -4617,7 +4617,7 @@ bool setScrollWidth (TableItem item, bool force) {
                     newWidth = Math.max (newWidth, rect.right - rect.left);
                 } else {
                     LPCTSTR buffer = StrToTCHARz (getCodePage (), string );
-                    newWidth = cast(int)/*64bit*/Math.max (newWidth, OS.SendMessage (handle, OS.LVM_GETSTRINGWIDTH, 0, cast(void*)buffer));
+                    newWidth = cast(int)/*64bit*/Math.max (newWidth, OS.SendMessage (handle, OS.LVM_GETSTRINGWIDTH, 0, cast(LPARAM)buffer));
                 }
             }
             if (item !is null) break;
@@ -4635,7 +4635,7 @@ bool setScrollWidth (TableItem item, bool force) {
         */
         if (newWidth is 0) {
             StringT buffer = StrToTCHARs (getCodePage (), " ", true);
-            newWidth = cast(int)/*64bit*/Math.max (newWidth, OS.SendMessage (handle, OS.LVM_GETSTRINGWIDTH, 0, cast(void*)buffer.ptr));
+            newWidth = cast(int)/*64bit*/Math.max (newWidth, OS.SendMessage (handle, OS.LVM_GETSTRINGWIDTH, 0, cast(LPARAM)buffer.ptr));
         }
         auto hStateList = cast(HANDLE) OS.SendMessage (handle, OS.LVM_GETIMAGELIST, OS.LVSIL_STATE, 0);
         if (hStateList !is null) {
@@ -4922,12 +4922,12 @@ void setTableEmpty () {
         * list is removed.
         */
         auto hImageList = OS.ImageList_Create (1, 1, 0, 0, 0);
-        OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, hImageList);
+        OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, cast(LPARAM)hImageList);
         OS.SendMessage (handle, OS.LVM_SETIMAGELIST, OS.LVSIL_SMALL, 0);
         if (headerImageList !is null) {
             auto hHeaderImageList = headerImageList.getHandle ();
             auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-            OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hHeaderImageList);
+            OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, cast(LPARAM)hHeaderImageList);
         }
         OS.ImageList_Destroy (hImageList);
         display.releaseImageList (imageList);
@@ -5010,7 +5010,7 @@ public void setTopIndex (int index) {
     RECT rect;
     rect.left = OS.LVIR_BOUNDS;
     ignoreCustomDraw = true;
-    OS.SendMessage (handle, OS.LVM_GETITEMRECT, 0, &rect);
+    OS.SendMessage (handle, OS.LVM_GETITEMRECT, 0, cast(LPARAM)&rect);
     ignoreCustomDraw = false;
     auto dy = (index - topIndex) * (rect.bottom - rect.top);
     OS.SendMessage (handle, OS.LVM_SCROLL, 0, dy);
@@ -5055,7 +5055,7 @@ public void showColumn (TableColumn column) {
     if (index is 0) {
         itemRect.top = 1;
         ignoreCustomDraw = true;
-        OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, -1, &itemRect);
+        OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, -1, cast(LPARAM)&itemRect);
         ignoreCustomDraw = false;
         itemRect.right = itemRect.left;
         auto width = cast(int)/*64bit*/OS.SendMessage (handle, OS.LVM_GETCOLUMNWIDTH, 0, 0);
@@ -5063,7 +5063,7 @@ public void showColumn (TableColumn column) {
     } else {
         itemRect.top = index;
         ignoreCustomDraw = true;
-        OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, -1, &itemRect);
+        OS.SendMessage (handle, OS.LVM_GETSUBITEMRECT, -1, cast(LPARAM)&itemRect);
         ignoreCustomDraw = false;
     }
     /*
@@ -5296,13 +5296,13 @@ void updateHeaderToolTips () {
     lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
     for (int i=0; i<columnCount; i++) {
         TableColumn column = columns [i];
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &rect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&rect) !is 0) {
             lpti.uId = column.id = display.nextToolTipId++;
             lpti.rect.left = rect.left;
             lpti.rect.top = rect.top;
             lpti.rect.right = rect.right;
             lpti.rect.bottom = rect.bottom;
-            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, &lpti);
+            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
         }
     }
 }
@@ -5423,7 +5423,7 @@ override .LRESULT windowProc (HWND hwnd, int msg, WPARAM wParam, LPARAM lParam) 
                         pinfo.pt.x = pt.x;
                         pinfo.pt.y = pt.y;
                         auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
-                        auto index = OS.SendMessage (hwndHeader, OS.HDM_HITTEST, 0, &pinfo);
+                        auto index = OS.SendMessage (hwndHeader, OS.HDM_HITTEST, 0, cast(LPARAM)&pinfo);
                         if (0 <= index && index < columnCount && !columns [index].resizable) {
                             if ((pinfo.flags & (OS.HHT_ONDIVIDER | OS.HHT_ONDIVOPEN)) !is 0) {
                                 OS.SetCursor (OS.LoadCursor (null, cast(TCHAR*)OS.IDC_ARROW));
@@ -5520,7 +5520,7 @@ override .LRESULT windowProc (HWND hwnd, int msg, WPARAM wParam, LPARAM lParam) 
             if ((style & SWT.MIRRORED) !is 0) {
                 shdi.ptOffset.x = shdi.sizeDragImage.cx - shdi.ptOffset.x; 
             }
-            OS.MoveMemory (lParam, &shdi, SHDRAGIMAGE.sizeof);
+            OS.MoveMemory (cast(LPVOID)lParam, &shdi, SHDRAGIMAGE.sizeof);
             return 1;
         }
     }
@@ -5706,7 +5706,7 @@ override LRESULT WM_LBUTTONDBLCLK (WPARAM wParam, LPARAM lParam) {
     LVHITTESTINFO pinfo;
     pinfo.pt.x = OS.GET_X_LPARAM (lParam);
     pinfo.pt.y = OS.GET_Y_LPARAM (lParam);
-    int index = cast(int)/*64bit*/OS.SendMessage (handle, OS.LVM_HITTEST, 0, &pinfo);
+    int index = cast(int)/*64bit*/OS.SendMessage (handle, OS.LVM_HITTEST, 0, cast(LPARAM)&pinfo);
     Display display = this.display;
     display.captureChanged = false;
     sendMouseEvent (SWT.MouseDown, 1, handle, OS.WM_LBUTTONDOWN, wParam, lParam);
@@ -5766,7 +5766,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
         * the correct way to determine that the user has selected
         * the check box, equality is needed.
         */
-        int index = cast(int)/*64bit*/OS.SendMessage (handle, OS.LVM_HITTEST, 0, &pinfo);
+        int index = cast(int)/*64bit*/OS.SendMessage (handle, OS.LVM_HITTEST, 0, cast(LPARAM)&pinfo);
         if (index !is -1 && pinfo.flags is OS.LVHT_ONITEMSTATEICON) {
             TableItem item = _getItem (index);
             item.setChecked (!item.getChecked (), true);
@@ -5878,7 +5878,7 @@ override LRESULT WM_RBUTTONDBLCLK (WPARAM wParam, LPARAM lParam) {
     LVHITTESTINFO pinfo;
     pinfo.pt.x = OS.GET_X_LPARAM (lParam);
     pinfo.pt.y = OS.GET_Y_LPARAM (lParam);
-    OS.SendMessage (handle, OS.LVM_HITTEST, 0, &pinfo);
+    OS.SendMessage (handle, OS.LVM_HITTEST, 0, cast(LPARAM)&pinfo);
     Display display = this.display;
     display.captureChanged = false;
     sendMouseEvent (SWT.MouseDown, 3, handle, OS.WM_RBUTTONDOWN, wParam, lParam);
@@ -5931,7 +5931,7 @@ override LRESULT WM_SETFOCUS (WPARAM wParam, LPARAM lParam) {
         lvItem.state = OS.LVIS_FOCUSED;
         lvItem.stateMask = OS.LVIS_FOCUSED;
         ignoreSelect = true;
-        OS.SendMessage (handle, OS.LVM_SETITEMSTATE, 0, &lvItem);
+        OS.SendMessage (handle, OS.LVM_SETITEMSTATE, 0, cast(LPARAM)&lvItem);
         ignoreSelect = false;
     }
     return result;
@@ -6087,7 +6087,7 @@ override LRESULT WM_HSCROLL (WPARAM wParam, LPARAM lParam) {
             bool [] visible = new bool [columnCount];
             for (int i=0; i<columnCount; i++) {
                 visible [i] = true;
-                if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &headerRect) !is 0) {
+                if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&headerRect) !is 0) {
                     OS.MapWindowPoints (hwndHeader, handle, cast(POINT*)&headerRect, 2);
                     visible [i] = OS.IntersectRect(&headerRect, &rect, &headerRect) !is 0;
                 }
@@ -6186,7 +6186,7 @@ override LRESULT WM_VSCROLL (WPARAM wParam, LPARAM lParam) {
             bool [] visible = new bool [columnCount];
             for (int i=0; i<columnCount; i++) {
                 visible [i] = true;
-                if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &headerRect) !is 0) {
+                if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&headerRect) !is 0) {
                     OS.MapWindowPoints (hwndHeader, handle, cast(POINT*)&headerRect, 2);
                     visible [i] = OS.IntersectRect(&headerRect, &rect, &headerRect) !is 0;
                 }
@@ -6539,11 +6539,11 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                         RECT itemRect;
                         itemRect.left = OS.LVIR_BOUNDS;
                         ignoreCustomDraw = true;
-                        OS.SendMessage (handle, OS. LVM_GETITEMRECT, pnmlv.iItem, &itemRect);
+                        OS.SendMessage (handle, OS. LVM_GETITEMRECT, pnmlv.iItem, cast(LPARAM)&itemRect);
                         ignoreCustomDraw = false;
                         RECT headerRect;
                         auto index = OS.SendMessage (hwndHeader, OS.HDM_ORDERTOINDEX, count - 1, 0);
-                        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+                        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
                         OS.MapWindowPoints (hwndHeader, handle, cast(POINT*) &headerRect, 2);
                         rect.left = headerRect.right;
                         rect.top = itemRect.top;
@@ -6667,7 +6667,7 @@ LRESULT wmNotifyHeader (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                 if ((pitem.mask & OS.HDI_ORDER) !is 0 && pitem.iOrder !is -1) {
                     if (columnCount is 0) break;
                     int [] order = new int [columnCount];
-                    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, order.ptr);
+                    OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, cast(LPARAM)order.ptr);
                     int index = 0;
                     while (index < order.length) {
                         if (order [index] is phdn.iItem) break;
@@ -6728,7 +6728,7 @@ LRESULT wmNotifyHeader (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                             TableColumn [] newColumns = new TableColumn [columnCount];
                             System.arraycopy (columns, 0, newColumns, 0, columnCount);
                             int [] order = new int [columnCount];
-                            OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, order.ptr);
+                            OS.SendMessage (handle, OS.LVM_GETCOLUMNORDERARRAY, columnCount, cast(LPARAM)order.ptr);
                             bool moved = false;
                             for (int i=0; i<columnCount; i++) {
                                 TableColumn nextColumn = newColumns [order [i]];
@@ -6786,7 +6786,7 @@ LRESULT wmNotifyToolTip (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                 OS.ScreenToClient (handle, &pt);
                 pinfo.pt.x = pt.x;
                 pinfo.pt.y = pt.y;
-                if (OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, &pinfo) !is -1) {
+                if (OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, cast(LPARAM)&pinfo) !is -1) {
                     TableItem item = _getItem (pinfo.iItem);
                     auto hDC = OS.GetDC (handle);
                     HFONT oldFont, newFont = cast(HFONT)OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
@@ -6814,7 +6814,7 @@ LRESULT wmNotifyToolTip (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                                 }
                             } else {
                                 lpnmtdi = cast(NMTTDISPINFO*)new NMTTDISPINFOW;
-                                OS.MoveMemory (lpnmtdi, lParam, NMTTDISPINFOW.sizeof);
+                                OS.MoveMemory (lpnmtdi, cast(LPCVOID)lParam, NMTTDISPINFOW.sizeof);
                                 if (lpnmtdi.lpszText !is null) {
                                     (cast(wchar*)lpnmtdi.lpszText)[0] = 0;
                                 }
@@ -6837,10 +6837,10 @@ LRESULT wmNotifyToolTip (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                                         CHAR [] bytes = new CHAR [chars.length * 2];
                                         OS.WideCharToMultiByte (getCodePage (), 0, chars.ptr, cast(int)/*64bit*/chars.length, bytes.ptr, cast(int)/*64bit*/bytes.length, null, null);
                                         shell.setToolTipText (lpnmtdi, bytes);
-                                        OS.MoveMemory (lParam, cast(NMTTDISPINFOA*)lpnmtdi, NMTTDISPINFOA.sizeof);
+                                        OS.MoveMemory (cast(LPVOID)lParam, cast(NMTTDISPINFOA*)lpnmtdi, NMTTDISPINFOA.sizeof);
                                     } else {
                                         shell.setToolTipText (lpnmtdi, chars);
-                                        OS.MoveMemory (lParam, cast(NMTTDISPINFOW*)lpnmtdi, NMTTDISPINFOW.sizeof);
+                                        OS.MoveMemory (cast(LPVOID)lParam, cast(NMTTDISPINFOW*)lpnmtdi, NMTTDISPINFOW.sizeof);
                                     }
                                 }
                             }
@@ -6878,7 +6878,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW* nmcd, LPARAM lParam) {
             OS.ScreenToClient (handle, &pt);
             pinfo.pt.x = pt.x;
             pinfo.pt.y = pt.y;
-            if (OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, &pinfo) !is -1) {
+            if (OS.SendMessage (handle, OS.LVM_SUBITEMHITTEST, 0, cast(LPARAM)&pinfo) !is -1) {
                 TableItem item = _getItem (pinfo.iItem);
                 auto hDC = OS.GetDC (handle);
                 auto hFont = item.fontHandle (pinfo.iSubItem);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TableColumn.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TableColumn.d
@@ -344,7 +344,7 @@ public void pack () {
     auto hwnd = parent.handle;
     auto oldWidth = OS.SendMessage (hwnd, OS.LVM_GETCOLUMNWIDTH, index, 0);
     LPCTSTR buffer = StrToTCHARz (parent.getCodePage (), text);
-    auto headerWidth = OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, cast(void*)buffer) + Table.HEADER_MARGIN;
+    auto headerWidth = OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, cast(LPARAM)buffer) + Table.HEADER_MARGIN;
     if (OS.COMCTL32_MAJOR >= 6 && OS.IsAppThemed ()) headerWidth += Table.HEADER_EXTRA;
     bool hasHeaderImage = false;
     if (image !is null || parent.sortColumn is this) {
@@ -384,7 +384,7 @@ public void pack () {
     if ((index is 0 && !parent.firstColumnImage) || parent.hooks (SWT.MeasureItem)) {
         RECT headerRect;
         auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
         OS.MapWindowPoints (hwndHeader, hwnd, cast(POINT*) &headerRect, 2);
         auto hDC = OS.GetDC (hwnd);
         HFONT oldFont, newFont = cast(HFONT) OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0);
@@ -570,14 +570,14 @@ public void setAlignment (int alignment) {
     auto hwnd = parent.handle;
     LVCOLUMN lvColumn;
     lvColumn.mask = OS.LVCF_FMT;
-    OS.SendMessage (hwnd, OS.LVM_GETCOLUMN, index, &lvColumn);
+    OS.SendMessage (hwnd, OS.LVM_GETCOLUMN, index, cast(LPARAM)&lvColumn);
     lvColumn.fmt &= ~OS.LVCFMT_JUSTIFYMASK;
     int fmt = 0;
     if ((style & SWT.LEFT) is SWT.LEFT) fmt = OS.LVCFMT_LEFT;
     if ((style & SWT.CENTER) is SWT.CENTER) fmt = OS.LVCFMT_CENTER;
     if ((style & SWT.RIGHT) is SWT.RIGHT) fmt = OS.LVCFMT_RIGHT;
     lvColumn.fmt |= fmt;
-    OS.SendMessage (hwnd, OS.LVM_SETCOLUMN, index, &lvColumn);
+    OS.SendMessage (hwnd, OS.LVM_SETCOLUMN, index, cast(LPARAM)&lvColumn);
     /*
     * Bug in Windows.  When LVM_SETCOLUMN is used to change
     * the alignment of a column, the column is not redrawn
@@ -589,7 +589,7 @@ public void setAlignment (int alignment) {
         RECT rect, headerRect;
         OS.GetClientRect (hwnd, &rect);
         auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
         OS.MapWindowPoints (hwndHeader, hwnd, cast(POINT*) &headerRect, 2);
         rect.left = headerRect.left;
         rect.right = headerRect.right;
@@ -616,7 +616,7 @@ void setImage (Image image, bool sort, bool right) {
         auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
         HDITEM hdItem;
         hdItem.mask = OS.HDI_FORMAT | OS.HDI_IMAGE | OS.HDI_BITMAP;
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
         hdItem.fmt &= ~OS.HDF_BITMAP_ON_RIGHT;
         if (image !is null) {
             if (sort) {
@@ -634,11 +634,11 @@ void setImage (Image image, bool sort, bool right) {
         } else {
             hdItem.fmt &= ~(OS.HDF_IMAGE | OS.HDF_BITMAP);
         }
-        OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+        OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
     } else {
         LVCOLUMN lvColumn;
         lvColumn.mask = OS.LVCF_FMT | OS.LVCF_IMAGE;
-        OS.SendMessage (hwnd, OS.LVM_GETCOLUMN, index, &lvColumn);
+        OS.SendMessage (hwnd, OS.LVM_GETCOLUMN, index, cast(LPARAM)&lvColumn);
         if (image !is null) {
             lvColumn.fmt |= OS.LVCFMT_IMAGE;
             lvColumn.iImage = parent.imageIndexHeader (image);
@@ -647,7 +647,7 @@ void setImage (Image image, bool sort, bool right) {
             lvColumn.mask &= ~OS.LVCF_IMAGE;
             lvColumn.fmt &= ~(OS.LVCFMT_IMAGE | OS.LVCFMT_BITMAP_ON_RIGHT);
         }
-        OS.SendMessage (hwnd, OS.LVM_SETCOLUMN, index, &lvColumn);
+        OS.SendMessage (hwnd, OS.LVM_SETCOLUMN, index, cast(LPARAM)&lvColumn);
     }
 }
 
@@ -705,7 +705,7 @@ void setSortDirection (int direction) {
         auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
         HDITEM hdItem;
         hdItem.mask = OS.HDI_FORMAT | OS.HDI_IMAGE;
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
         switch (direction) {
             case SWT.UP:
                 hdItem.fmt &= ~(OS.HDF_IMAGE | OS.HDF_SORTDOWN);
@@ -729,7 +729,7 @@ void setSortDirection (int direction) {
                 break;
             default:
         }
-        OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+        OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
         /*
         * Bug in Windows.  When LVM_SETSELECTEDCOLUMN is used to
         * specify a selected column, Windows does not redraw either
@@ -752,7 +752,7 @@ void setSortDirection (int direction) {
             OS.SendMessage (hwnd, OS.LVM_SETSELECTEDCOLUMN, newColumn, 0);
             RECT headerRect;
             if (oldColumn !is -1) {
-                if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, oldColumn, &headerRect) !is 0) {
+                if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, oldColumn, cast(LPARAM)&headerRect) !is 0) {
                     OS.MapWindowPoints (hwndHeader, hwnd, cast(POINT*) &headerRect, 2);
                     rect.left = headerRect.left;
                     rect.right = headerRect.right;
@@ -761,7 +761,7 @@ void setSortDirection (int direction) {
             }
         }
         RECT headerRect;
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect) !is 0) {
             OS.MapWindowPoints (hwndHeader, hwnd, cast(POINT*)  &headerRect, 2);
             rect.left = headerRect.left;
             rect.right = headerRect.right;
@@ -800,7 +800,7 @@ override public void setText (String string) {
     auto hwnd = parent.handle;
     LVCOLUMN lvColumn;
     lvColumn.mask = OS.LVCF_FMT;
-    OS.SendMessage (hwnd, OS.LVM_GETCOLUMN, index, &lvColumn);
+    OS.SendMessage (hwnd, OS.LVM_GETCOLUMN, index, cast(LPARAM)&lvColumn);
 
     /*
     * Bug in Windows.  When a column header contains a
@@ -817,7 +817,7 @@ override public void setText (String string) {
     OS.MoveMemory (pszText, buffer.ptr, byteCount);
     lvColumn.mask |= OS.LVCF_TEXT;
     lvColumn.pszText = pszText;
-    auto result = OS.SendMessage (hwnd, OS.LVM_SETCOLUMN, index, &lvColumn);
+    auto result = OS.SendMessage (hwnd, OS.LVM_SETCOLUMN, index, cast(LPARAM)&lvColumn);
     if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
     if (result is 0) error (SWT.ERROR_CANNOT_SET_TEXT);
 }
@@ -870,7 +870,7 @@ void updateToolTip (int index) {
         auto hwnd = parent.handle;
         auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
         RECT rect;
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &rect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&rect) !is 0) {
             TOOLINFO lpti;
             lpti.cbSize = OS.TOOLINFO_sizeof;
             lpti.hwnd = hwndHeader;
@@ -879,7 +879,7 @@ void updateToolTip (int index) {
             lpti.rect.top = rect.top;
             lpti.rect.right = rect.right;
             lpti.rect.bottom = rect.bottom;
-            OS.SendMessage (hwndHeaderToolTip, OS.TTM_NEWTOOLRECT, 0, &lpti);
+            OS.SendMessage (hwndHeaderToolTip, OS.TTM_NEWTOOLRECT, 0, cast(LPARAM)&lpti);
         }
     }
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TableItem.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TableItem.d
@@ -269,7 +269,7 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
         if (parent.explorerTheme) {
             rect.left = OS.LVIR_ICON;
             parent.ignoreCustomDraw = true;
-            auto code = OS.SendMessage (hwnd, OS. LVM_GETITEMRECT, row, &rect);
+            auto code = OS.SendMessage (hwnd, OS. LVM_GETITEMRECT, row, cast(LPARAM)&rect);
             parent.ignoreCustomDraw = false;
             if (code is 0) return RECT.init;
             if (getText) {
@@ -277,7 +277,7 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
                 auto hFont = fontHandle (column);
                 if (hFont is cast(HFONT)-1 && hDC is null) {
                     LPCTSTR buffer = StrToTCHARz (parent.getCodePage (), text);
-                    width = OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, cast(void*)buffer);
+                    width = OS.SendMessage (hwnd, OS.LVM_GETSTRINGWIDTH, 0, cast(LPARAM)buffer);
                 } else {
                     StringT buffer = StrToTCHARs (parent.getCodePage (), text, false);
                     auto textDC = hDC !is null ? hDC : OS.GetDC (hwnd), oldFont = cast(HFONT)-1;
@@ -301,21 +301,21 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
             if (getText) {
                 rect.left = OS.LVIR_SELECTBOUNDS;
                 parent.ignoreCustomDraw = true;
-                auto code = OS.SendMessage (hwnd, OS.LVM_GETITEMRECT, row, &rect);
+                auto code = OS.SendMessage (hwnd, OS.LVM_GETITEMRECT, row, cast(LPARAM)&rect);
                 parent.ignoreCustomDraw = false;
                 if (code is 0) return RECT.init;
                 if (!getImage) {
                     RECT iconRect;
                     iconRect.left = OS.LVIR_ICON;
                     parent.ignoreCustomDraw = true;
-                    code = OS.SendMessage (hwnd, OS. LVM_GETITEMRECT, row, &iconRect);
+                    code = OS.SendMessage (hwnd, OS. LVM_GETITEMRECT, row, cast(LPARAM)&iconRect);
                     parent.ignoreCustomDraw = false;
                     if (code !is 0) rect.left = iconRect.right;
                 }
             } else {
                 rect.left = OS.LVIR_ICON;
                 parent.ignoreCustomDraw = true;
-                auto code = OS.SendMessage (hwnd, OS.LVM_GETITEMRECT, row, &rect);
+                auto code = OS.SendMessage (hwnd, OS.LVM_GETITEMRECT, row, cast(LPARAM)&rect);
                 parent.ignoreCustomDraw = false;
                 if (code is 0) return RECT.init;
             }
@@ -323,7 +323,7 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
         if (fullText || fullImage) {
             RECT headerRect;
             auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, 0, &headerRect);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, 0, cast(LPARAM)&headerRect);
             OS.MapWindowPoints (hwndHeader, hwnd, cast(POINT*) &headerRect, 2);
             if (getText && fullText) rect.right = headerRect.right;
             if (getImage && fullImage) rect.left = headerRect.left;
@@ -346,7 +346,7 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
             */
             rect.left = getText ? OS.LVIR_LABEL : OS.LVIR_ICON;
             parent.ignoreCustomDraw = true;
-            auto code = OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, &rect);
+            auto code = OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, cast(LPARAM)&rect);
             parent.ignoreCustomDraw = false;
             if (code is 0) return RECT.init;
             /*
@@ -362,7 +362,7 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
                 RECT iconRect;
                 iconRect.left = OS.LVIR_ICON;
                 parent.ignoreCustomDraw = true;
-                code = OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, &iconRect);
+                code = OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, cast(LPARAM)&iconRect);
                 parent.ignoreCustomDraw = false;
                 if (code !is 0) rect.left = iconRect.left;
             }
@@ -371,7 +371,7 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
                     RECT iconRect;
                     iconRect.top = column;
                     iconRect.left = OS.LVIR_ICON;
-                    if (OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, &iconRect) !is 0) {
+                    if (OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, cast(LPARAM)&iconRect) !is 0) {
                         rect.left = iconRect.right + Table.INSET / 2;
                     }
                 }
@@ -381,14 +381,14 @@ RECT getBounds (int row, int column, bool getText, bool getImage, bool fullText,
             if (column is 0 && fullImage) {
                 RECT headerRect;
                 auto hwndHeader = cast(HWND) OS.SendMessage (hwnd, OS.LVM_GETHEADER, 0, 0);
-                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, 0, &headerRect);
+                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, 0, cast(LPARAM)&headerRect);
                 OS.MapWindowPoints (hwndHeader, hwnd, cast(POINT*) &headerRect, 2);
                 rect.left = headerRect.left;
             }
         } else {
             rect.left = OS.LVIR_ICON;
             parent.ignoreCustomDraw = true;
-            auto code = OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, &rect);
+            auto code = OS.SendMessage (hwnd, OS. LVM_GETSUBITEMRECT, row, cast(LPARAM)&rect);
             parent.ignoreCustomDraw = false;
             if (code is 0) return RECT.init;
             if (!hasImage) rect.right = rect.left;
@@ -876,7 +876,7 @@ public void setFont (Font font){
             lvItem.mask = OS.LVIF_TEXT;
             lvItem.iItem = itemIndex;
             lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-            OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, &lvItem);
+            OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
             cached = false;
         }
     }
@@ -940,7 +940,7 @@ public void setFont (int index, Font font) {
                 lvItem.mask = OS.LVIF_TEXT;
                 lvItem.iItem = itemIndex;
                 lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-                OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, &lvItem);
+                OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
                 cached = false;
             }
         }
@@ -1147,7 +1147,7 @@ public void setImageIndent (int indent) {
             lvItem.mask = OS.LVIF_INDENT;
             lvItem.iItem = index;
             lvItem.iIndent = indent;
-            OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, &lvItem);
+            OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
         }
     }
     parent.setScrollWidth (this, false);
@@ -1220,7 +1220,7 @@ public void setText (int index, String string) {
                 lvItem.mask = OS.LVIF_TEXT;
                 lvItem.iItem = itemIndex;
                 lvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-                OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, &lvItem);
+                OS.SendMessage (hwnd, OS.LVM_SETITEM, 0, cast(LPARAM)&lvItem);
                 cached = false;
             }
         }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
@@ -369,7 +369,7 @@ public void append (String string) {
     * handler from WM_CHAR.
     */
     ignoreCharacter = true;
-    OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+    OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
     ignoreCharacter = false;
     OS.SendMessage (handle, OS.EM_SCROLLCARET, 0, 0);
 }
@@ -547,7 +547,7 @@ override int defaultBackground () {
 override bool dragDetect (HWND hwnd, int x, int y, bool filter, bool [] detect, bool [] consume) {
     if (filter) {
         int start, end;
-        OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+        OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
         if (start !is end ) {
             auto lParam = OS.MAKELPARAM (x, y);
             int position = OS.LOWORD (OS.SendMessage (handle, OS.EM_CHARFROMPOS, 0, lParam));
@@ -682,7 +682,7 @@ public Point getCaretLocation () {
         if (position >= OS.GetWindowTextLength (handle)) {
             int cp = getCodePage ();
             int start, end;
-            OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             OS.SendMessage (handle, OS.EM_SETSEL, position, position);
             /*
             * Feature in Windows.  When an edit control with ES_MULTILINE
@@ -696,10 +696,10 @@ public Point getCaretLocation () {
             * handler from WM_CHAR.
             */
             ignoreCharacter = ignoreModify = true;
-            OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(void*)StrToTCHARz (cp, " "));
+            OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(LPARAM)StrToTCHARz (cp, " "));
             caretPos = OS.SendMessage (handle, OS.EM_POSFROMCHAR, position, 0);
             OS.SendMessage (handle, OS.EM_SETSEL, position, position + 1);
-            OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(void*)StrToTCHARz (cp, ""));
+            OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(LPARAM)StrToTCHARz (cp, ""));
             ignoreCharacter = ignoreModify = false;
             OS.SendMessage (handle, OS.EM_SETSEL, start , start );
             OS.SendMessage (handle, OS.EM_SETSEL, start , end );
@@ -724,7 +724,7 @@ public Point getCaretLocation () {
 public int getCaretPosition () {
     checkWidget ();
     int start, end;
-    OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     /*
     * In Windows, there is no API to get the position of the caret
     * when the selection is not an i-beam.  The best that can be done
@@ -993,7 +993,7 @@ public String getMessage () {
 public Point getSelection () {
     checkWidget ();
     int start, end;
-    OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     if (!OS.IsUnicode && OS.IsDBLocale) {
         start = mbcsToWcsPos (start);
         end = mbcsToWcsPos (end);
@@ -1032,7 +1032,7 @@ public String getSelectionText () {
     int length = OS.GetWindowTextLength (handle);
     if (length is 0) return "";
     int start, end;
-    OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     if (start is end ) return "";
     TCHAR[] buffer = NewTCHARs (getCodePage (), length + 1);
     OS.GetWindowText (handle, buffer.ptr, length + 1);
@@ -1199,7 +1199,7 @@ public int getTopPixel () {
     * of Rich Edit return zero.
     */
     int [2] buffer;
-    auto code = OS.SendMessage (handle, OS.EM_GETSCROLLPOS, 0, buffer.ptr);
+    auto code = OS.SendMessage (handle, OS.EM_GETSCROLLPOS, 0, cast(LPARAM)buffer.ptr);
     if (code is 1) return buffer [1];
     return getTopIndex () * getLineHeight ();
 }
@@ -1224,7 +1224,7 @@ public void insert (String string) {
     string = Display.withCrLf (string);
     if (hooks (SWT.Verify) || filters (SWT.Verify)) {
         int start, end;
-        OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+        OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
         string = verifyText (string, start, end, null);
         if (string is null) return;
     }
@@ -1241,7 +1241,7 @@ public void insert (String string) {
     * handler from WM_CHAR.
     */
     ignoreCharacter = true;
-    OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+    OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
     ignoreCharacter = false;
 }
 
@@ -1265,7 +1265,7 @@ int mbcsToWcsPos (int mbcsPos) {
             //ENDIAN
             buffer [0] = cast(char) (mbcsSize & 0xFF);
             buffer [1] = cast(char) (mbcsSize >> 8);
-            mbcsSize = OS.SendMessageA (handle, OS.EM_GETLINE, line, buffer.ptr);
+            mbcsSize = OS.SendMessageA (handle, OS.EM_GETLINE, line, cast(LPARAM)buffer.ptr);
             wcsSize = OS.MultiByteToWideChar (cp, OS.MB_PRECOMPOSED, buffer.ptr, cast(int)/*64bit*/mbcsSize, null, 0);
         }
         if (line - 1 !is count) {
@@ -1437,7 +1437,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
     /* Verify the character */
     String oldText = "";
     int start, end; //Windows' indices: UTF-16 or Windows 8-bit character set
-    OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     switch (key) {
         case 0x08:  /* Bs */
             if (start is end ) {
@@ -1450,7 +1450,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
                     if (!OS.IsUnicode && OS.IsDBLocale) {
                         int newStart, newEnd;
                         OS.SendMessage (handle, OS.EM_SETSEL, start, end);
-                        OS.SendMessage (handle, OS.EM_GETSEL, &newStart, &newEnd);
+                        OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                         if (start !is newStart) start = start - 1;
                     }
                 }
@@ -1470,7 +1470,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
                     if (!OS.IsUnicode && OS.IsDBLocale) {
                         int newStart, newEnd;
                         OS.SendMessage (handle, OS.EM_SETSEL, start, end);
-                        OS.SendMessage (handle, OS.EM_GETSEL, &newStart, &newEnd);
+                        OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                         if (end !is newEnd) end = end + 1;
                     }
                 }
@@ -1504,7 +1504,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
     * handler from WM_CHAR.
     */
     ignoreCharacter = true;
-    OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+    OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
     ignoreCharacter = false;
     return false;
 }
@@ -1532,7 +1532,7 @@ override void setBounds (int x, int y, int width, int height, int flags) {
         int marginWidth = OS.LOWORD (margins) + OS.HIWORD (margins);
         if (rect.right - rect.left <= marginWidth) {
             int start, end;
-            OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             if (start !is 0 || end !is 0) {
                 SetWindowPos (handle, null, x, y, width, height, flags);
                 OS.SendMessage (handle, OS.EM_SETSEL, 0, 0);
@@ -1674,7 +1674,7 @@ public void setMessage (String message) {
         if ((style & SWT.SEARCH) !is 0) {
             int bits = OS.GetWindowLong (handle, OS.GWL_STYLE);
             if ((bits & OS.ES_MULTILINE) is 0) {
-                OS.SendMessage (handle, OS.EM_SETCUEBANNER, 0, cast(void*)StrToTCHARz( 0, message ));
+                OS.SendMessage (handle, OS.EM_SETCUEBANNER, 0, cast(LPARAM)StrToTCHARz( 0, message ));
             }
         }
     }
@@ -1792,7 +1792,7 @@ override public void setRedraw (bool redraw) {
     */
     if (drawCount !is 0) return;
     int start, end;
-    OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     if (!redraw) {
         oldStart = start;  oldEnd = end;
     } else {
@@ -1866,7 +1866,7 @@ void setTabStops (int tabs) {
     * number of space widths, depending on the font.
     */
     int width = (getTabWidth (tabs) * 4) / OS.LOWORD (OS.GetDialogBaseUnits ());
-    OS.SendMessage (handle, OS.EM_SETTABSTOPS, 1, &width);
+    OS.SendMessage (handle, OS.EM_SETTABSTOPS, 1, cast(LPARAM)&width);
 }
 
 /**
@@ -2025,7 +2025,7 @@ int wcsToMbcsPos (int wcsPos) {
             //ENDIAN
             buffer [0] = cast(char) (mbcsSize & 0xFF);
             buffer [1] = cast(char) (mbcsSize >> 8);
-            mbcsSize = OS.SendMessageA (handle, OS.EM_GETLINE, line, buffer.ptr);
+            mbcsSize = OS.SendMessageA (handle, OS.EM_GETLINE, line, cast(LPARAM)buffer.ptr);
             wcsSize = OS.MultiByteToWideChar (cp, OS.MB_PRECOMPOSED, buffer.ptr, cast(int)/*64bit*/mbcsSize, null, 0);
         }
         if (line - 1 !is count) {
@@ -2281,7 +2281,7 @@ override LRESULT WM_LBUTTONDBLCLK (WPARAM wParam, LPARAM lParam) {
     * and avoid calling the window proc.
     */
     int start, end;
-    OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+    OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
     if (start  is end ) {
         int length = OS.GetWindowTextLength (handle);
         if (length is start) {
@@ -2358,7 +2358,7 @@ LRESULT wmClipboard (int msg, WPARAM wParam, LPARAM lParam) {
     switch (msg) {
         case OS.WM_CLEAR:
         case OS.WM_CUT:
-            OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+            OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
             if (start !is end ) {
                 newText = "";
                 call = true;
@@ -2372,11 +2372,11 @@ LRESULT wmClipboard (int msg, WPARAM wParam, LPARAM lParam) {
         case OS.WM_UNDO:
             if (OS.SendMessage (handle, OS.EM_CANUNDO, 0, 0) !is 0) {
                 ignoreModify = ignoreCharacter = true;
-                OS.SendMessage (handle, OS.EM_GETSEL, &start, &end);
+                OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&start, cast(LPARAM)&end);
                 callWindowProc (handle, msg, wParam, lParam);
                 int length = OS.GetWindowTextLength (handle);
                 int newStart, newEnd;
-                OS.SendMessage (handle, OS.EM_GETSEL, &newStart, &newEnd);
+                OS.SendMessage (handle, OS.EM_GETSEL, cast(WPARAM)&newStart, cast(LPARAM)&newEnd);
                 if (length !is 0 && newStart !is newEnd) {
                     TCHAR[] buffer = NewTCHARs (getCodePage (), length + 1);
                     OS.GetWindowText (handle, buffer.ptr, length + 1);
@@ -2412,7 +2412,7 @@ LRESULT wmClipboard (int msg, WPARAM wParam, LPARAM lParam) {
             * handler from WM_CHAR.
             */
             ignoreCharacter = true;
-            OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(void*)buffer);
+            OS.SendMessage (handle, OS.EM_REPLACESEL, 0, cast(LPARAM)buffer);
             ignoreCharacter = false;
             return LRESULT.ZERO;
         }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/ToolBar.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/ToolBar.d
@@ -225,14 +225,14 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
         TBBUTTON lpButton;
         auto count = OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
         for (int i=0; i<count; i++) {
-            OS.SendMessage (handle, OS.TB_GETITEMRECT, i, &rect);
+            OS.SendMessage (handle, OS.TB_GETITEMRECT, i, cast(LPARAM)&rect);
             height = Math.max (height, rect.bottom);
-            OS.SendMessage (handle, OS.TB_GETBUTTON, i, &lpButton);
+            OS.SendMessage (handle, OS.TB_GETBUTTON, i, cast(LPARAM)&lpButton);
             if ((lpButton.fsStyle & OS.BTNS_SEP) !is 0) {
                 TBBUTTONINFO info;
                 info.cbSize = TBBUTTONINFO.sizeof;
                 info.dwMask = OS.TBIF_SIZE;
-                OS.SendMessage (handle, OS.TB_GETBUTTONINFO, lpButton.idCommand, &info);
+                OS.SendMessage (handle, OS.TB_GETBUTTONINFO, lpButton.idCommand, cast(LPARAM)&info);
                 width = Math.max (width, info.cx);
             } else {
                 width = Math.max (width, rect.right);
@@ -254,7 +254,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
         auto count = OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
         if (count !is 0) {
             RECT rect;
-            OS.SendMessage (handle, OS.TB_GETITEMRECT, count - 1, &rect);
+            OS.SendMessage (handle, OS.TB_GETITEMRECT, count - 1, cast(LPARAM)&rect);
             width = Math.max (width, rect.right);
             height = Math.max (height, rect.bottom);
         }
@@ -337,7 +337,7 @@ override void createHandle () {
     * create.
     */
     HFONT hFont = OS.GetStockObject (OS.SYSTEM_FONT);
-    OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+    OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
 
     /* Set the button struct, bitmap and button sizes */
     OS.SendMessage (handle, OS.TB_BUTTONSTRUCTSIZE, TBBUTTON.sizeof, 0);
@@ -379,7 +379,7 @@ void createItem (ToolItem item, int index) {
     * separators cannot show images.
     */
     if ((bits & OS.BTNS_SEP) is 0) lpButton.iBitmap = OS.I_IMAGENONE;
-    if (OS.SendMessage (handle, OS.TB_INSERTBUTTON, index, &lpButton) is 0) {
+    if (OS.SendMessage (handle, OS.TB_INSERTBUTTON, index, cast(LPARAM)&lpButton) is 0) {
         error (SWT.ERROR_ITEM_NOT_ADDED);
     }
     items [item.id = id] = item;
@@ -402,7 +402,7 @@ void destroyItem (ToolItem item) {
     TBBUTTONINFO info;
     info.cbSize = TBBUTTONINFO.sizeof;
     info.dwMask = OS.TBIF_IMAGE | OS.TBIF_STYLE;
-    auto index = OS.SendMessage (handle, OS.TB_GETBUTTONINFO, item.id, &info);
+    auto index = OS.SendMessage (handle, OS.TB_GETBUTTONINFO, item.id, cast(LPARAM)&info);
     /*
     * Feature in Windows.  For some reason, a tool item that has
     * the style BTNS_SEP does not return I_IMAGENONE when queried
@@ -499,7 +499,7 @@ public ToolItem getItem (int index) {
     auto count = OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
     if (!(0 <= index && index < count)) error (SWT.ERROR_INVALID_RANGE);
     TBBUTTON lpButton;
-    auto result = OS.SendMessage (handle, OS.TB_GETBUTTON, index, &lpButton);
+    auto result = OS.SendMessage (handle, OS.TB_GETBUTTON, index, cast(LPARAM)&lpButton);
     if (result is 0) error (SWT.ERROR_CANNOT_GET_ITEM);
     return items [lpButton.idCommand];
 }
@@ -568,7 +568,7 @@ public ToolItem [] getItems () {
     TBBUTTON lpButton;
     ToolItem [] result = new ToolItem [count];
     for (int i=0; i<count; i++) {
-        OS.SendMessage (handle, OS.TB_GETBUTTON, i, &lpButton);
+        OS.SendMessage (handle, OS.TB_GETBUTTON, i, cast(LPARAM)&lpButton);
         result [i] = items [lpButton.idCommand];
     }
     return result;
@@ -661,7 +661,7 @@ void layoutItems () {
                 * the tool bar to redraw and lay out.
                 */
                 auto hFont = cast(HFONT) OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
-                OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+                OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
                 setDropDownItems (true);
             }
         }
@@ -695,7 +695,7 @@ void layoutItems () {
         for (int i=0; i<items.length; i++) {
             ToolItem item = items [i];
             if (item !is null && (item.style & SWT.SEPARATOR) is 0) {
-                OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, &info);
+                OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, cast(LPARAM)&info);
             }
         }
     }
@@ -708,7 +708,7 @@ void layoutItems () {
 override bool mnemonicHit (wchar ch) {
     int key = Display.wcsToMbcs (ch, 0);
     int id;
-    if (OS.SendMessage (handle, OS.TB_MAPACCELERATOR, key, &id) is 0) {
+    if (OS.SendMessage (handle, OS.TB_MAPACCELERATOR, key, cast(LPARAM)&id) is 0) {
         return false;
     }
     if ((style & SWT.FLAT) !is 0 && !setTabGroupFocus ()) return false;
@@ -722,7 +722,7 @@ override bool mnemonicHit (wchar ch) {
 override bool mnemonicMatch (wchar ch) {
     int key = Display.wcsToMbcs (ch, 0);
     int id;
-    if (OS.SendMessage (handle, OS.TB_MAPACCELERATOR, key, &id) is 0) {
+    if (OS.SendMessage (handle, OS.TB_MAPACCELERATOR, key, cast(LPARAM)&id) is 0) {
         return false;
     }
     /*
@@ -865,13 +865,13 @@ void setDropDownItems (bool set) {
                     TBBUTTONINFO info;
                     info.cbSize = TBBUTTONINFO.sizeof;
                     info.dwMask = OS.TBIF_STYLE;
-                    OS.SendMessage (handle, OS.TB_GETBUTTONINFO, item.id, &info);
+                    OS.SendMessage (handle, OS.TB_GETBUTTONINFO, item.id, cast(LPARAM)&info);
                     if (set) {
                         info.fsStyle |= OS.BTNS_DROPDOWN;
                     } else {
                         info.fsStyle &= ~OS.BTNS_DROPDOWN;
                     }
-                    OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, &info);
+                    OS.SendMessage (handle, OS.TB_SETBUTTONINFO, item.id, cast(LPARAM)&info);
                 }
             }
         }
@@ -885,7 +885,7 @@ void setDisabledImageList (ImageList imageList) {
         hImageList = disabledImageList.getHandle ();
     }
     setDropDownItems (false);
-    OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, hImageList);
+    OS.SendMessage (handle, OS.TB_SETDISABLEDIMAGELIST, 0, cast(LPARAM)hImageList);
     setDropDownItems (true);
 }
 
@@ -921,7 +921,7 @@ void setHotImageList (ImageList imageList) {
         hImageList = hotImageList.getHandle ();
     }
     setDropDownItems (false);
-    OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, hImageList);
+    OS.SendMessage (handle, OS.TB_SETHOTIMAGELIST, 0, cast(LPARAM)hImageList);
     setDropDownItems (true);
 }
 
@@ -932,14 +932,14 @@ void setImageList (ImageList imageList) {
         hImageList = imageList.getHandle ();
     }
     setDropDownItems (false);
-    OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, hImageList);
+    OS.SendMessage (handle, OS.TB_SETIMAGELIST, 0, cast(LPARAM)hImageList);
     setDropDownItems (true);
 }
 
 override public bool setParent (Composite parent) {
     checkWidget ();
     if (!super.setParent (parent)) return false;
-    OS.SendMessage (handle, OS.TB_SETPARENT, parent.handle, 0);
+    OS.SendMessage (handle, OS.TB_SETPARENT, cast(WPARAM)parent.handle, 0);
     return true;
 }
 
@@ -1096,7 +1096,7 @@ override LRESULT WM_CHAR (WPARAM wParam, LPARAM lParam) {
             auto index = OS.SendMessage (handle, OS.TB_GETHOTITEM, 0, 0);
             if (index !is -1) {
                 TBBUTTON lpButton;
-                auto code = OS.SendMessage (handle, OS.TB_GETBUTTON, index, &lpButton);
+                auto code = OS.SendMessage (handle, OS.TB_GETBUTTON, index, cast(LPARAM)&lpButton);
                 if (code !is 0) {
                     items [lpButton.idCommand].click (false);
                     return LRESULT.ZERO;
@@ -1180,7 +1180,7 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
 override LRESULT WM_KILLFOCUS (WPARAM wParam, LPARAM lParam) {
     auto index = OS.SendMessage (handle, OS.TB_GETHOTITEM, 0, 0);
     TBBUTTON lpButton;
-    auto code = OS.SendMessage (handle, OS.TB_GETBUTTON, index, &lpButton);
+    auto code = OS.SendMessage (handle, OS.TB_GETBUTTON, index, cast(LPARAM)&lpButton);
     if (code !is 0) lastFocusId = lpButton.idCommand;
     return super.WM_KILLFOCUS (wParam, lParam);
 }
@@ -1213,10 +1213,10 @@ override LRESULT WM_MOUSELEAVE (WPARAM wParam, LPARAM lParam) {
         TOOLINFO lpti;
         lpti.cbSize = OS.TOOLINFO_sizeof;
         auto hwndToolTip = cast(HWND) OS.SendMessage (handle, OS.TB_GETTOOLTIPS, 0, 0);
-        if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+        if (OS.SendMessage (hwndToolTip, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
             if ((lpti.uFlags & OS.TTF_IDISHWND) is 0) {
-                OS.SendMessage (hwndToolTip, OS.TTM_DELTOOL, 0, &lpti);
-                OS.SendMessage (hwndToolTip, OS.TTM_ADDTOOL, 0, &lpti);
+                OS.SendMessage (hwndToolTip, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
+                OS.SendMessage (hwndToolTip, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
             }
         }
     }
@@ -1281,7 +1281,7 @@ override LRESULT WM_SIZE (WPARAM wParam, LPARAM lParam) {
         RECT rect;
         auto count = OS.SendMessage (handle, OS.TB_BUTTONCOUNT, 0, 0);
         while (index < count) {
-            OS.SendMessage (handle, OS.TB_GETITEMRECT, index, &rect);
+            OS.SendMessage (handle, OS.TB_GETITEMRECT, index, cast(LPARAM)&rect);
             OS.MapWindowPoints (handle, null, cast(POINT*) &rect, 2);
             if (rect.right > windowRect.right - border * 2) break;
             index++;
@@ -1328,7 +1328,7 @@ override LRESULT WM_WINDOWPOSCHANGING (WPARAM wParam, LPARAM lParam) {
     OS.GetClientRect (handle, &oldRect);
     RECT newRect;
     OS.SetRect (&newRect, 0, 0, lpwp.cx, lpwp.cy);
-    OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, &newRect);
+    OS.SendMessage (handle, OS.WM_NCCALCSIZE, 0, cast(LPARAM)&newRect);
     int oldWidth = oldRect.right - oldRect.left;
     int newWidth = newRect.right - newRect.left;
     if (newWidth > oldWidth) {
@@ -1357,7 +1357,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                 event.detail = SWT.ARROW;
                 auto index = OS.SendMessage (handle, OS.TB_COMMANDTOINDEX, lpnmtb.iItem, 0);
                 RECT rect;
-                OS.SendMessage (handle, OS.TB_GETITEMRECT, index, &rect);
+                OS.SendMessage (handle, OS.TB_GETITEMRECT, index, cast(LPARAM)&rect);
                 event.x = rect.left;
                 event.y = rect.bottom;
                 child.postEvent (SWT.Selection, event);
@@ -1406,7 +1406,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                         OS.GetClientRect (handle, &client);
                         auto index = OS.SendMessage (handle, OS.TB_COMMANDTOINDEX, lpnmhi.idNew, 0);
                         RECT rect;
-                        OS.SendMessage (handle, OS.TB_GETITEMRECT, index, &rect);
+                        OS.SendMessage (handle, OS.TB_GETITEMRECT, index, cast(LPARAM)&rect);
                         if (rect.right > client.right || rect.bottom > client.bottom) {
                             return LRESULT.ONE;
                         }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/ToolItem.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/ToolItem.d
@@ -185,7 +185,7 @@ void click (bool dropDown) {
     if (OS.GetKeyState (OS.VK_LBUTTON) < 0) return;
     auto index = OS.SendMessage (hwnd, OS.TB_COMMANDTOINDEX, id, 0);
     RECT rect;
-    OS.SendMessage (hwnd, OS.TB_GETITEMRECT, index, &rect);
+    OS.SendMessage (hwnd, OS.TB_GETITEMRECT, index, cast(LPARAM)&rect);
     auto hotIndex = OS.SendMessage (hwnd, OS.TB_GETHOTITEM, 0, 0);
 
     /*
@@ -228,7 +228,7 @@ public Rectangle getBounds () {
     auto hwnd = parent.handle;
     auto index = OS.SendMessage (hwnd, OS.TB_COMMANDTOINDEX, id, 0);
     RECT rect;
-    OS.SendMessage (hwnd, OS.TB_GETITEMRECT, index, &rect);
+    OS.SendMessage (hwnd, OS.TB_GETITEMRECT, index, cast(LPARAM)&rect);
     int width = rect.right - rect.left;
     int height = rect.bottom - rect.top;
     return new Rectangle (rect.left, rect.top, width, height);
@@ -383,7 +383,7 @@ public int getWidth () {
     auto hwnd = parent.handle;
     auto index = OS.SendMessage (hwnd, OS.TB_COMMANDTOINDEX, id, 0);
     RECT rect;
-    OS.SendMessage (hwnd, OS.TB_GETITEMRECT, index, &rect);
+    OS.SendMessage (hwnd, OS.TB_GETITEMRECT, index, cast(LPARAM)&rect);
     return rect.right - rect.left;
 }
 
@@ -428,7 +428,7 @@ void releaseImages () {
     info.cbSize = TBBUTTONINFO.sizeof;
     info.dwMask = OS.TBIF_IMAGE | OS.TBIF_STYLE;
     auto hwnd = parent.handle;
-    OS.SendMessage (hwnd, OS.TB_GETBUTTONINFO, id, &info);
+    OS.SendMessage (hwnd, OS.TB_GETBUTTONINFO, id, cast(LPARAM)&info);
     /*
     * Feature in Windows.  For some reason, a tool item that has
     * the style BTNS_SEP does not return I_IMAGENONE when queried
@@ -547,7 +547,7 @@ public void setControl (Control control) {
         TBBUTTONINFO info;
         info.cbSize = TBBUTTONINFO.sizeof;
         info.dwMask = OS.TBIF_STYLE | OS.TBIF_STATE;
-        OS.SendMessage (hwnd, OS.TB_GETBUTTONINFO, id, &info);
+        OS.SendMessage (hwnd, OS.TB_GETBUTTONINFO, id, cast(LPARAM)&info);
         if (control is null) {
             if ((info.fsStyle & OS.BTNS_SEP) is 0) {
                 changed = true;
@@ -570,7 +570,7 @@ public void setControl (Control control) {
             }
         }
         if (changed) {
-            OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, &info);
+            OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, cast(LPARAM)&info);
             /*
             * Bug in Windows.  When TB_SETBUTTONINFO changes the
             * style of a tool item from BTNS_SEP to BTNS_BUTTON
@@ -790,7 +790,7 @@ override public void setText (String string) {
         OS.MoveMemory (pszText, buffer.ptr, byteCount);
         info.pszText = pszText;
     }
-    OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, &info);
+    OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, cast(LPARAM)&info);
     if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
 
     /*
@@ -843,7 +843,7 @@ public void setWidth (int width) {
     info.cbSize = TBBUTTONINFO.sizeof;
     info.dwMask = OS.TBIF_SIZE;
     info.cx = cast(short) width;
-    OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, &info);
+    OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, cast(LPARAM)&info);
     parent.layoutItems ();
 }
 
@@ -853,7 +853,7 @@ void updateImages (bool enabled) {
     TBBUTTONINFO info;
     info.cbSize = TBBUTTONINFO.sizeof;
     info.dwMask = OS.TBIF_IMAGE;
-    OS.SendMessage (hwnd, OS.TB_GETBUTTONINFO, id, &info);
+    OS.SendMessage (hwnd, OS.TB_GETBUTTONINFO, id, cast(LPARAM)&info);
     if (info.iImage is OS.I_IMAGENONE && image is null) return;
     ImageList imageList = parent.getImageList ();
     ImageList hotImageList = parent.getHotImageList ();
@@ -938,7 +938,7 @@ void updateImages (bool enabled) {
     */
     info.dwMask |= OS.TBIF_SIZE;
     info.cx = 0;
-    OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, &info);
+    OS.SendMessage (hwnd, OS.TB_SETBUTTONINFO, id, cast(LPARAM)&info);
 
     parent.layoutItems ();
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/ToolTip.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/ToolTip.d
@@ -230,7 +230,7 @@ public bool getVisible () {
     if (OS.SendMessage (hwndToolTip_, OS.TTM_GETCURRENTTOOL, 0, 0) !is 0) {
         TOOLINFO lpti;
         lpti.cbSize = OS.TOOLINFO_sizeof;
-        if (OS.SendMessage (hwndToolTip_, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+        if (OS.SendMessage (hwndToolTip_, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
             return (lpti.uFlags & OS.TTF_IDISHWND) is 0 && lpti.uId is id;
         }
     }
@@ -276,10 +276,10 @@ override void releaseWidget () {
             if (OS.SendMessage (hwndToolTip_, OS.TTM_GETCURRENTTOOL, 0, 0) !is 0) {
                 TOOLINFO lpti;
                 lpti.cbSize = OS.TOOLINFO_sizeof;
-                if (OS.SendMessage (hwndToolTip_, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+                if (OS.SendMessage (hwndToolTip_, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
                     if ((lpti.uFlags & OS.TTF_IDISHWND) is 0) {
                         if (lpti.uId is id) {
-                            OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 0, &lpti);
+                            OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 0, cast(LPARAM)&lpti);
                             OS.SendMessage (hwndToolTip_, OS.TTM_POP, 0, 0);
                             OS.KillTimer (hwndToolTip_, TIMER_ID);
                         }
@@ -507,17 +507,17 @@ public void setVisible (bool visible) {
                 HCURSOR hCursor = OS.GetCursor ();
                 OS.SetCursor (null);
                 OS.SetCursorPos (rect.left, rect.top);
-                OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 1, &lpti);
+                OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 1, cast(LPARAM)&lpti);
                 OS.SetCursorPos (pt.x, pt.y);
                 OS.SetCursor (hCursor);
             } else {
-                OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 1, &lpti);
+                OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 1, cast(LPARAM)&lpti);
             }
 
             auto time = OS.SendMessage (hwndToolTip_, OS.TTM_GETDELAYTIME, OS.TTDT_AUTOPOP, 0);
             OS.SetTimer (hwndToolTip_, TIMER_ID, cast(int)/*64bit*/time, null);
         } else {
-            OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 0, &lpti);
+            OS.SendMessage (hwndToolTip_, OS.TTM_TRACKACTIVATE, 0, cast(LPARAM)&lpti);
             OS.SendMessage (hwndToolTip_, OS.TTM_POP, 0, 0);
             OS.KillTimer (hwndToolTip_, TIMER_ID);
         }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Tree.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Tree.d
@@ -285,7 +285,7 @@ TreeItem _getItem (HANDLE hItem) {
     TVITEM tvItem;
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
     tvItem.hItem = cast(HTREEITEM)hItem;
-    if (OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem) !is 0) {
+    if (OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem) !is 0) {
         return _getItem (tvItem.hItem, tvItem.lParam);
     }
     return null;
@@ -456,7 +456,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
         OS.MapWindowPoints (hwndParent, handle, cast(POINT*) &clientRect, 2);
         if (columnCount !is 0) {
             order = new int [columnCount];
-            OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, order.ptr);
+            OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)order.ptr);
         }
     }
     int sortIndex = -1, clrSortBk = -1;
@@ -475,7 +475,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
         if (columnCount > 0 && hwndHeader !is null) {
             HDITEM hdItem;
             hdItem.mask = OS.HDI_WIDTH;
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
             width = hdItem.cxy;
         }
         if (i is 0) {
@@ -495,7 +495,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
                             if (columnCount > 0 && hwndHeader !is null) {
                                 HDITEM hdItem;
                                 hdItem.mask = OS.HDI_WIDTH;
-                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
                                 pClipRect.right = Math.min (pClipRect.right, nmcd.nmcd.rc.left + hdItem.cxy);
                             }
                         }
@@ -506,7 +506,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
                             HDITEM hdItem;
                             hdItem.mask = OS.HDI_WIDTH;
                             for (int j=0; j<columnCount; j++) {
-                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, j, &hdItem);
+                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, j, cast(LPARAM)&hdItem);
                                 totalWidth += hdItem.cxy;
                             }
                             if (totalWidth > clientRect.right - clientRect.left) {
@@ -717,7 +717,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
                                             HDITEM hdItem;
                                             hdItem.mask = OS.HDI_WIDTH;
                                             for (int j=0; j<columnCount; j++) {
-                                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, j, &hdItem);
+                                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, j, cast(LPARAM)&hdItem);
                                                 totalWidth += hdItem.cxy;
                                             }
                                             if (totalWidth > clientRect.right - clientRect.left) {
@@ -908,7 +908,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
             if (columnCount !is 0) {
                 HDITEM hdItem;
                 hdItem.mask = OS.HDI_WIDTH;
-                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, 0, &hdItem);
+                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, 0, cast(LPARAM)&hdItem);
                 RECT rect;
                 OS.SetRect (&rect, nmcd.nmcd.rc.left + hdItem.cxy, nmcd.nmcd.rc.top, nmcd.nmcd.rc.right, nmcd.nmcd.rc.bottom);
                 OS.DrawEdge (hDC, &rect, OS.BDR_SUNKENINNER, OS.BF_BOTTOM);
@@ -985,7 +985,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
             clipRect = new RECT ();
             HDITEM hdItem;
             hdItem.mask = OS.HDI_WIDTH;
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
             OS.SetRect (clipRect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.left + hdItem.cxy, nmcd.nmcd.rc.bottom);
         }
     }
@@ -1179,7 +1179,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                     } else {
                         nmcd.clrText = newColor;
                     }
-                    OS.MoveMemory (lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
+                    OS.MoveMemory (cast(LPVOID)lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
                 }
             }
             if (focused && !ignoreDrawFocus && (style & SWT.FULL_SELECTION) is 0) {
@@ -1188,12 +1188,12 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                     textRect.right = Math.min (cellRect.right, measureEvent.x + measureEvent.width);
                 }
                 nmcd.nmcd.uItemState &= ~OS.CDIS_FOCUS;
-                OS.MoveMemory (lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
+                OS.MoveMemory (cast(LPVOID)lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
                 focusRect = textRect;
             }
             if (explorerTheme) {
                 if (selected || (hot && ignoreDrawHot)) nmcd.nmcd.uItemState &= ~OS.CDIS_HOT;
-                OS.MoveMemory (lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
+                OS.MoveMemory (cast(LPVOID)lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
             }
             RECT* itemRect = item.getBounds (index, true, true, false, false, false, hDC);
             OS.SaveDC (hDC);
@@ -1229,7 +1229,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                     if (OS.IsWindowEnabled (handle)) drawBackground (hDC, &rect);
                 }
                 nmcd.nmcd.uItemState &= ~OS.CDIS_FOCUS;
-                OS.MoveMemory (lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
+                OS.MoveMemory (cast(LPVOID)lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
             }
         }
     }
@@ -1252,7 +1252,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                         RECT rect;
                         HDITEM hdItem;
                         hdItem.mask = OS.HDI_WIDTH;
-                        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+                        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
                         OS.SetRect (&rect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.left + hdItem.cxy, nmcd.nmcd.rc.bottom);
                         if (OS.COMCTL32_MAJOR < 6 || !OS.IsAppThemed ()) {
                             RECT itemRect;
@@ -1281,7 +1281,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
             if (!selected) {
                 nmcd.clrText = clrText is -1 ? getForegroundPixel () : clrText;
                 nmcd.clrTextBk = clrTextBk is -1 ? getBackgroundPixel () : clrTextBk;
-                OS.MoveMemory (lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
+                OS.MoveMemory (cast(LPVOID)lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
             }
         }
     }
@@ -1312,14 +1312,14 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                     } else {
                         nmcd.clrText = newColor;
                     }
-                    OS.MoveMemory (lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
+                    OS.MoveMemory (cast(LPVOID)lParam, nmcd, NMTVCUSTOMDRAW.sizeof);
                     if (clrTextBk !is -1) {
                         if ((style & SWT.FULL_SELECTION) !is 0) {
                             RECT rect;
                             if (columnCount !is 0) {
                                 HDITEM hdItem;
                                 hdItem.mask = OS.HDI_WIDTH;
-                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+                                OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
                                 OS.SetRect (&rect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.left + hdItem.cxy, nmcd.nmcd.rc.bottom);
                             } else {
                                 OS.SetRect (&rect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.right, nmcd.nmcd.rc.bottom);
@@ -1343,7 +1343,7 @@ LRESULT CDDS_ITEMPREPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
             RECT rect;
             HDITEM hdItem;
             hdItem.mask = OS.HDI_WIDTH;
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
             OS.SetRect (&rect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.left + hdItem.cxy, nmcd.nmcd.rc.bottom);
             fillBackground (hDC, clrSortBk, &rect);
         }
@@ -1400,7 +1400,7 @@ LRESULT CDDS_POSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                         RECT rect;
                         OS.SetRect (&rect, nmcd.nmcd.rc.left, top, nmcd.nmcd.rc.right, nmcd.nmcd.rc.bottom);
                         RECT headerRect;
-                        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+                        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
                         rect.left = headerRect.left;
                         rect.right = headerRect.right;
                         fillBackground (nmcd.nmcd.hdc, getSortColumnPixel (), &rect);
@@ -1417,7 +1417,7 @@ LRESULT CDDS_POSTPAINT (NMTVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                 hdItem.mask = OS.HDI_WIDTH;
                 for (int i=0; i<columnCount; i++) {
                     auto index = OS.SendMessage (hwndHeader, OS.HDM_ORDERTOINDEX, i, 0);
-                    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
                     OS.SetRect (&rect, x, nmcd.nmcd.rc.top, x + hdItem.cxy, nmcd.nmcd.rc.bottom);
                     OS.DrawEdge (hDC, &rect, OS.BDR_SUNKENINNER, OS.BF_RIGHT);
                     x += hdItem.cxy;
@@ -1505,14 +1505,14 @@ override .LRESULT callWindowProc (HWND hwnd, int msg, WPARAM wParam, LPARAM lPar
                     TVITEM tvItem;
                     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
                     tvItem.hItem = cast(HTREEITEM)hItem;
-                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                     hSelect = hItem;
                     ignoreDeselect = ignoreSelect = lockSelection = true;
-                    OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, hItem);
+                    OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, cast(LPARAM)hItem);
                     ignoreDeselect = ignoreSelect = lockSelection = false;
                     hSelect = null;
                     if ((tvItem.state & OS.TVIS_SELECTED) is 0) {
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     }
                 }
             }
@@ -1701,9 +1701,9 @@ bool checkScroll (HANDLE hItem) {
     */
     if (drawCount is 0) return false;
     auto hRoot = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_ROOT, 0);
-    auto hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hItem);
+    auto hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hItem);
     while (hParent !is hRoot && hParent !is 0) {
-        hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hParent);
+        hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hParent);
     }
     return hParent is 0;
 }
@@ -1745,7 +1745,7 @@ public void clear (int index, bool all) {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
     clear (hItem, &tvItem);
     if (all) {
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
         clearAll (hItem, &tvItem, all);
     }
 }
@@ -1753,7 +1753,7 @@ public void clear (int index, bool all) {
 void clear (HANDLE hItem, TVITEM* tvItem) {
     tvItem.hItem = cast(HTREEITEM)hItem;
     TreeItem item = null;
-    if (OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem) !is 0) {
+    if (OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)tvItem) !is 0) {
         item = tvItem.lParam !is -1 ? items [tvItem.lParam] : null;
     }
     if (item !is null) {
@@ -1807,10 +1807,10 @@ void clearAll (HANDLE hItem, TVITEM* tvItem, bool all) {
     while (hItem !is null) {
         clear (hItem, tvItem);
         if (all) {
-            auto hFirstItem = cast(HANDLE)OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+            auto hFirstItem = cast(HANDLE)OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
             clearAll (hFirstItem, tvItem, all);
         }
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
     }
 }
 
@@ -1830,7 +1830,7 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
         HDITEM hdItem;
         hdItem.mask = OS.HDI_WIDTH;
         for (int i=0; i<columnCount; i++) {
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, i, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, i, cast(LPARAM)&hdItem);
             width += hdItem.cxy;
         }
         RECT rect;
@@ -1846,14 +1846,14 @@ override public Point computeSize (int wHint, int hHint, bool changed) {
             tvItem.hItem = cast(HTREEITEM)hItem;
             tvItem.pszText = OS.LPSTR_TEXTCALLBACK;
             ignoreCustomDraw = true;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             ignoreCustomDraw = false;
         }
         if (OS.TreeView_GetItemRect (handle, cast(HTREEITEM)hItem, &rect, true)) {
             width = Math.max (width, rect.right);
             height += rect.bottom - rect.top;
         }
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hItem);
     }
     if (width is 0) width = DEFAULT_WIDTH;
     if (height is 0) height = DEFAULT_HEIGHT;
@@ -1928,7 +1928,7 @@ override void createHandle () {
     * create.
     */
     HFONT hFont = OS.GetStockObject (OS.SYSTEM_FONT);
-    OS.SendMessage (handle, OS.WM_SETFONT, hFont, 0);
+    OS.SendMessage (handle, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
 }
 
 void createHeaderToolTips () {
@@ -2040,7 +2040,7 @@ void createItem (TreeColumn column, int index) {
     if ((column.style & SWT.LEFT) is SWT.LEFT) hdItem.fmt = OS.HDF_LEFT;
     if ((column.style & SWT.CENTER) is SWT.CENTER) hdItem.fmt = OS.HDF_CENTER;
     if ((column.style & SWT.RIGHT) is SWT.RIGHT) hdItem.fmt = OS.HDF_RIGHT;
-    OS.SendMessage (hwndHeader, OS.HDM_INSERTITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_INSERTITEM, index, cast(LPARAM)&hdItem);
     if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
 
     /* When the first column is created, hide the horizontal scroll bar */
@@ -2078,7 +2078,7 @@ void createItem (TreeColumn column, int index) {
     /* Add the tool tip item for the header */
     if (headerToolTipHandle !is null) {
         RECT rect;
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &rect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&rect) !is 0) {
             TOOLINFO lpti;
             lpti.cbSize = OS.TOOLINFO_sizeof;
             lpti.uFlags = OS.TTF_SUBCLASS;
@@ -2089,7 +2089,7 @@ void createItem (TreeColumn column, int index) {
             lpti.rect.right = rect.right;
             lpti.rect.bottom = rect.bottom;
             lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
-            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, &lpti);
+            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
         }
     }
 }
@@ -2120,7 +2120,7 @@ void createItem (TreeItem item, HANDLE hParent, HANDLE hInsertAfter, HANDLE hIte
         lastID = id + 1;
     }
     HANDLE hNewItem;
-    HANDLE hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hParent);
+    HANDLE hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hParent);
     bool fixParent = hFirstItem is null;
     if (hItem is null) {
         TVINSERTSTRUCT tvInsert;
@@ -2136,7 +2136,7 @@ void createItem (TreeItem item, HANDLE hParent, HANDLE hInsertAfter, HANDLE hIte
             tvInsert.item.stateMask = OS.TVIS_STATEIMAGEMASK;
         }
         ignoreCustomDraw = true;
-        hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_INSERTITEM, 0, &tvInsert);
+        hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_INSERTITEM, 0, cast(LPARAM)&tvInsert);
         ignoreCustomDraw = false;
         if (hNewItem is null) error (SWT.ERROR_ITEM_NOT_ADDED);
         /*
@@ -2152,7 +2152,7 @@ void createItem (TreeItem item, HANDLE hParent, HANDLE hInsertAfter, HANDLE hIte
         tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
         tvItem.hItem = cast(HTREEITEM)( hNewItem = hItem );
         tvItem.lParam = id;
-        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     }
     if (item !is null) {
         item.handle = hNewItem;
@@ -2254,7 +2254,7 @@ void createItemToolTips () {
     lpti.uId = cast(ptrdiff_t)handle;
     lpti.uFlags = OS.TTF_SUBCLASS | OS.TTF_TRANSPARENT;
     lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
-    OS.SendMessage (itemToolTipHandle, OS.TTM_ADDTOOL, 0, &lpti);
+    OS.SendMessage (itemToolTipHandle, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
 }
 
 void createParent () {
@@ -2313,7 +2313,7 @@ void createParent () {
 //      }
 //  }
     HFONT hFont = cast(HFONT) OS.SendMessage (handle, OS.WM_GETFONT, 0, 0);
-    if (hFont !is null) OS.SendMessage (hwndHeader, OS.WM_SETFONT, hFont, 0);
+    if (hFont !is null) OS.SendMessage (hwndHeader, OS.WM_SETFONT, cast(WPARAM)hFont, 0);
     HANDLE hwndInsertAfter = OS.GetWindow (handle, OS.GW_HWNDPREV);
     int flags = OS.SWP_NOSIZE | OS.SWP_NOMOVE | OS.SWP_NOACTIVATE;
     SetWindowPos (hwndParent, hwndInsertAfter, 0, 0, 0, 0, flags);
@@ -2360,11 +2360,11 @@ void deselect (HANDLE hItem, TVITEM* tvItem, HANDLE hIgnoreItem) {
     while (hItem !is null) {
         if (hItem !is hIgnoreItem) {
             tvItem.hItem = cast(HTREEITEM)hItem;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)tvItem);
         }
-        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
         deselect (hFirstItem, tvItem, hIgnoreItem);
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
     }
 }
 
@@ -2393,7 +2393,7 @@ public void deselect (TreeItem item) {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
     tvItem.stateMask = OS.TVIS_SELECTED;
     tvItem.hItem = cast(HTREEITEM)item.handle;
-    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
 }
 
 /**
@@ -2413,7 +2413,7 @@ public void deselectAll () {
         HANDLE hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CARET, 0);
         if (hItem !is null) {
             tvItem.hItem = cast(HTREEITEM)hItem;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
         }
     } else {
         auto oldProc = OS.GetWindowLongPtr (handle, OS.GWLP_WNDPROC);
@@ -2426,7 +2426,7 @@ public void deselectAll () {
                 TreeItem item = items [i];
                 if (item !is null) {
                     tvItem.hItem = cast(HTREEITEM)item.handle;
-                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                 }
             }
         }
@@ -2442,14 +2442,14 @@ void destroyItem (TreeColumn column) {
         index++;
     }
     int [] oldOrder = new int [columnCount];
-    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, oldOrder.ptr);
+    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)oldOrder.ptr);
     int orderIndex = 0;
     while (orderIndex < columnCount) {
         if (oldOrder [orderIndex] is index) break;
         orderIndex++;
     }
     RECT headerRect;
-    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
     if (OS.SendMessage (hwndHeader, OS.HDM_DELETEITEM, index, 0) is 0) {
         error (SWT.ERROR_ITEM_NOT_REMOVED);
     }
@@ -2534,10 +2534,10 @@ void destroyItem (TreeColumn column) {
             columns [0].style |= SWT.LEFT;
             HDITEM hdItem;
             hdItem.mask = OS.HDI_FORMAT | OS.HDI_IMAGE;
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
             hdItem.fmt &= ~OS.HDF_JUSTIFYMASK;
             hdItem.fmt |= OS.HDF_LEFT;
-            OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
         }
         RECT rect;
         OS.GetClientRect (handle, &rect);
@@ -2549,7 +2549,7 @@ void destroyItem (TreeColumn column) {
     updateScrollBar ();
     if (columnCount !is 0) {
         int [] newOrder = new int [columnCount];
-        OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, newOrder.ptr);
+        OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)newOrder.ptr);
         TreeColumn [] newColumns = new TreeColumn [columnCount - orderIndex];
         for (int i=orderIndex; i<newOrder.length; i++) {
             newColumns [i - orderIndex] = columns [newOrder [i]];
@@ -2568,7 +2568,7 @@ void destroyItem (TreeColumn column) {
         lpti.cbSize = OS.TOOLINFO_sizeof;
         lpti.uId = column.id;
         lpti.hwnd = hwndHeader;
-        OS.SendMessage (headerToolTipHandle, OS.TTM_DELTOOL, 0, &lpti);
+        OS.SendMessage (headerToolTipHandle, OS.TTM_DELTOOL, 0, cast(LPARAM)&lpti);
     }
 }
 
@@ -2599,7 +2599,7 @@ void destroyItem (TreeItem item, HANDLE hItem) {
         }
     }
     if (fixRedraw) {
-        hParent = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hItem);
+        hParent = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hItem);
         OS.UpdateWindow (handle);
         OS.DefWindowProc (handle, OS.WM_SETREDRAW, 0, 0);
         /*
@@ -2627,7 +2627,7 @@ void destroyItem (TreeItem item, HANDLE hItem) {
     }
 
     shrink = ignoreShrink = true;
-    OS.SendMessage (handle, OS.TVM_DELETEITEM, 0, hItem);
+    OS.SendMessage (handle, OS.TVM_DELETEITEM, 0, cast(LPARAM)hItem);
     ignoreShrink = false;
     if ((style & SWT.MULTI) !is 0) {
         ignoreDeselect = ignoreSelect = lockSelection = false;
@@ -2639,7 +2639,7 @@ void destroyItem (TreeItem item, HANDLE hItem) {
         * If the item that was deleted was the last child of a tree item that
         * is visible, redraw the parent item to force the + / - to be updated.
         */
-        if (OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hParent) is 0) {
+        if (OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hParent) is 0) {
             RECT rect;
             if (OS.TreeView_GetItemRect (handle, cast(HTREEITEM)hParent, &rect, false)) {
                 OS.InvalidateRect (handle, &rect, true);
@@ -2733,7 +2733,7 @@ bool findCell (int x, int y, ref TreeItem item, ref int index, ref RECT* cellRec
     TVHITTESTINFO lpht;
     lpht.pt.x = x;
     lpht.pt.y = y;
-    OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+    OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
     if (lpht.hItem !is null) {
         item = _getItem (lpht.hItem);
         POINT pt;
@@ -2752,7 +2752,7 @@ bool findCell (int x, int y, ref TreeItem item, ref int index, ref RECT* cellRec
         }
         int count = Math.max (1, columnCount);
         int [] order = new int [count];
-        if (hwndHeader !is null) OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, count, order.ptr);
+        if (hwndHeader !is null) OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, count, cast(LPARAM)order.ptr);
         index = 0;
         bool quit = false;
         while (index < count && !quit) {
@@ -2796,19 +2796,19 @@ int findIndex (HANDLE hFirstItem, HANDLE hItem) {
             return lastIndexOf = 0;
         }
         if (hLastIndexOf is hItem) return lastIndexOf;
-        auto hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, hLastIndexOf);
+        auto hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, cast(LPARAM)hLastIndexOf);
         if (hPrevItem is hItem) {
             hLastIndexOf = hPrevItem;
             return --lastIndexOf;
         }
-        HANDLE hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hLastIndexOf);
+        HANDLE hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hLastIndexOf);
         if (hNextItem is hItem) {
             hLastIndexOf = hNextItem;
             return ++lastIndexOf;
         }
         int previousIndex = lastIndexOf - 1;
         while (hPrevItem !is null && hPrevItem !is hItem) {
-            hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, hPrevItem);
+            hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, cast(LPARAM)hPrevItem);
             --previousIndex;
         }
         if (hPrevItem is hItem) {
@@ -2817,7 +2817,7 @@ int findIndex (HANDLE hFirstItem, HANDLE hItem) {
         }
         int nextIndex = lastIndexOf + 1;
         while (hNextItem !is null && hNextItem !is hItem) {
-            hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hNextItem);
+            hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hNextItem);
             nextIndex++;
         }
         if (hNextItem is hItem) {
@@ -2829,7 +2829,7 @@ int findIndex (HANDLE hFirstItem, HANDLE hItem) {
     int index = 0;
     auto hNextItem = hFirstItem;
     while (hNextItem !is null && hNextItem !is hItem) {
-        hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hNextItem);
+        hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hNextItem);
         index++;
     }
     if (hNextItem is hItem) {
@@ -2855,17 +2855,17 @@ HANDLE findItem (HANDLE hFirstItem, int index) {
         if (lastIndexOf is index) return hLastIndexOf;
         if (lastIndexOf - 1 is index) {
             --lastIndexOf;
-            return hLastIndexOf = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, hLastIndexOf);
+            return hLastIndexOf = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, cast(LPARAM)hLastIndexOf);
         }
         if (lastIndexOf + 1 is index) {
             lastIndexOf++;
-            return hLastIndexOf = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hLastIndexOf);
+            return hLastIndexOf = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hLastIndexOf);
         }
         if (index < lastIndexOf) {
             int previousIndex = lastIndexOf - 1;
-            auto hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, hLastIndexOf);
+            auto hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, cast(LPARAM)hLastIndexOf);
             while (hPrevItem !is null && index < previousIndex) {
-                hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, hPrevItem);
+                hPrevItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUS, cast(LPARAM)hPrevItem);
                 --previousIndex;
             }
             if (index is previousIndex) {
@@ -2874,9 +2874,9 @@ HANDLE findItem (HANDLE hFirstItem, int index) {
             }
         } else {
             int nextIndex = lastIndexOf + 1;
-            auto hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hLastIndexOf);
+            auto hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hLastIndexOf);
             while (hNextItem !is null && nextIndex < index) {
-                hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hNextItem);
+                hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hNextItem);
                 nextIndex++;
             }
             if (index is nextIndex) {
@@ -2889,7 +2889,7 @@ HANDLE findItem (HANDLE hFirstItem, int index) {
     int nextIndex = 0;
     auto hNextItem = hFirstItem;
     while (hNextItem !is null && nextIndex < index) {
-        hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hNextItem);
+        hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hNextItem);
         nextIndex++;
     }
     if (index is nextIndex) {
@@ -2980,7 +2980,7 @@ HANDLE getBottomItem () {
     if (hItem is null) return null;
     auto index = 0, count = OS.SendMessage (handle, OS.TVM_GETVISIBLECOUNT, 0, 0);
     while (index < count) {
-        HANDLE hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hItem);
+        HANDLE hNextItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hItem);
         if (hNextItem is null) return hItem;
         hItem = hNextItem;
         index++;
@@ -3076,7 +3076,7 @@ public int[] getColumnOrder () {
     checkWidget ();
     if (columnCount is 0) return null;
     int [] order = new int [columnCount];
-    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, order.ptr);
+    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)order.ptr);
     return order;
 }
 
@@ -3158,7 +3158,7 @@ TreeItem getItem (NMTVCUSTOMDRAW* nmcd) {
             TVITEM tvItem;
             tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
             tvItem.hItem = cast(HTREEITEM) nmcd.nmcd.dwItemSpec;
-            OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
             id = tvItem.lParam;
         }
     }
@@ -3194,7 +3194,7 @@ public TreeItem getItem (Point point) {
     TVHITTESTINFO lpht;
     lpht.pt.x = point.x;
     lpht.pt.y = point.y;
-    OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+    OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
     if (lpht.hItem !is null) {
         int flags = OS.TVHT_ONITEM;
         if ((style & SWT.FULL_SELECTION) !is 0) {
@@ -3241,7 +3241,7 @@ int getItemCount (HANDLE hItem) {
         count = lastIndexOf;
     }
     while (hFirstItem !is null) {
-        hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hFirstItem);
+        hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hFirstItem);
         count++;
     }
     if (hItem is hFirstIndexOf) itemCount = count;
@@ -3292,7 +3292,7 @@ TreeItem [] getItems (HANDLE hTreeItem) {
     int count = 0;
     auto hItem = hTreeItem;
     while (hItem !is null) {
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
         count++;
     }
     int index = 0;
@@ -3308,10 +3308,10 @@ TreeItem [] getItems (HANDLE hTreeItem) {
     * remove them from the list.
     */
     while (tvItem.hItem !is null) {
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         TreeItem item = _getItem (tvItem.hItem, tvItem.lParam);
         if (item !is null) result [index++] = item;
-        tvItem.hItem = cast(HTREEITEM) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, tvItem.hItem);
+        tvItem.hItem = cast(HTREEITEM) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)tvItem.hItem);
     }
     if (index !is count) {
         TreeItem [] newResult = new TreeItem [index];
@@ -3353,13 +3353,13 @@ HANDLE getNextSelection (HANDLE hItem, TVITEM* tvItem) {
             OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem);
             state = tvItem.state;
         } else {
-            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
         }
         if ((state & OS.TVIS_SELECTED) !is 0) return hItem;
-        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
         auto hSelected = getNextSelection (hFirstItem, tvItem);
         if (hSelected !is null) return hSelected;
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
     }
     return null;
 }
@@ -3385,7 +3385,7 @@ int getSelection (HANDLE hItem, TVITEM* tvItem, TreeItem [] selection, int index
     while (hItem !is null) {
         if (OS.IsWinCE || bigSelection) {
             tvItem.hItem = cast(HTREEITEM)hItem;
-            OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem);
+            OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)tvItem);
             if ((tvItem.state & OS.TVIS_SELECTED) !is 0) {
                 if (selection !is null && index < selection.length) {
                     selection [index] = _getItem (hItem, tvItem.lParam);
@@ -3393,11 +3393,11 @@ int getSelection (HANDLE hItem, TVITEM* tvItem, TreeItem [] selection, int index
                 index++;
             }
         } else {
-            auto state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+            auto state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
             if ((state & OS.TVIS_SELECTED) !is 0) {
                 if (tvItem !is null && selection !is null && index < selection.length) {
                     tvItem.hItem = cast(HTREEITEM)hItem;
-                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem);
+                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)tvItem);
                     selection [index] = _getItem (hItem, tvItem.lParam);
                 }
                 index++;
@@ -3405,13 +3405,13 @@ int getSelection (HANDLE hItem, TVITEM* tvItem, TreeItem [] selection, int index
         }
         if (index is count) break;
         if (all) {
-            auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+            auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
             if ((index = getSelection (hFirstItem, tvItem, selection, index, count, bigSelection, all)) is count) {
                 break;
             }
-            hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+            hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
         } else {
-            hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hItem);
+            hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hItem);
         }
     }
     return index;
@@ -3441,7 +3441,7 @@ public TreeItem [] getSelection () {
         TVITEM tvItem;
         tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM | OS.TVIF_STATE;
         tvItem.hItem = cast(HTREEITEM)hItem;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         if ((tvItem.state & OS.TVIS_SELECTED) is 0) return new TreeItem [0];
         return [_getItem (tvItem.hItem, tvItem.lParam)];
     }
@@ -3470,7 +3470,7 @@ public TreeItem [] getSelection () {
                     OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
                     state = tvItem.state;
                 } else {
-                    state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+                    state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
                 }
                 if ((state & OS.TVIS_SELECTED) !is 0) {
                     if (count < guess.length) guess [count] = item;
@@ -3523,7 +3523,7 @@ public int getSelectionCount () {
             OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
             state = tvItem.state;
         } else {
-            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
         }
         return (state & OS.TVIS_SELECTED) is 0 ? 0 : 1;
     }
@@ -3550,7 +3550,7 @@ public int getSelectionCount () {
                     OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem);
                     state = tvItem.state;
                 } else {
-                    state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+                    state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
                 }
                 if ((state & OS.TVIS_SELECTED) !is 0) count++;
             }
@@ -3680,7 +3680,7 @@ int imageIndex (Image image, int index) {
         auto hImageList = imageList.getHandle ();
         auto hOldImageList = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0);
         if (hOldImageList !is hImageList) {
-            OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, hImageList);
+            OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, cast(LPARAM)hImageList);
             updateScrollBar ();
         }
     }
@@ -3696,7 +3696,7 @@ int imageIndexHeader (Image image) {
         if (index is -1) index = headerImageList.add (image);
         auto hImageList = headerImageList.getHandle ();
         if (hwndHeader !is null) {
-            OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, hImageList);
+            OS.SendMessage (hwndHeader, OS.HDM_SETIMAGELIST, 0, cast(LPARAM)hImageList);
         }
         updateScrollBar ();
         return index;
@@ -3773,7 +3773,7 @@ bool isItemSelected (NMTVCUSTOMDRAW* nmcd) {
         TVITEM tvItem;
         tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
         tvItem.hItem = cast(HTREEITEM)nmcd.nmcd.dwItemSpec;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         if ((tvItem.state & (OS.TVIS_SELECTED | OS.TVIS_DROPHILITED)) !is 0) {
             selected = true;
             /*
@@ -3857,14 +3857,14 @@ void redrawSelection () {
                     OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
                     state = tvItem.state;
                 } else {
-                    state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+                    state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
                 }
                 if ((state & OS.TVIS_SELECTED) !is 0) {
                     if (OS.TreeView_GetItemRect (handle, cast(HTREEITEM)hItem, &rect, false)) {
                         OS.InvalidateRect (handle, &rect, true);
                     }
                 }
-                hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hItem);
+                hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hItem);
                 index++;
             }
         }
@@ -3881,7 +3881,7 @@ void releaseItem (HANDLE hItem, TVITEM* tvItem, bool release) {
     if (hItem is hAnchor) hAnchor = null;
     if (hItem is hInsert) hInsert = null;
     tvItem.hItem = cast(HTREEITEM)hItem;
-    if (OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem) !is 0) {
+    if (OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)tvItem) !is 0) {
         if (tvItem.lParam !is -1) {
             if (tvItem.lParam < lastID) lastID = cast(int)/*64bit*/tvItem.lParam;
             if (release) {
@@ -3894,11 +3894,11 @@ void releaseItem (HANDLE hItem, TVITEM* tvItem, bool release) {
 }
 
 void releaseItems (HANDLE hItem, TVITEM* tvItem) {
-    hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+    hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
     while (hItem !is null) {
         releaseItems (hItem, tvItem);
         releaseItem (hItem, tvItem, true);
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
     }
 }
 
@@ -4083,7 +4083,7 @@ public void setInsertMark (TreeItem item, bool before) {
     }
     hInsert = hItem;
     insertAfter = !before;
-    OS.SendMessage (handle, OS.TVM_SETINSERTMARK, insertAfter ? 1 : 0, hInsert);
+    OS.SendMessage (handle, OS.TVM_SETINSERTMARK, insertAfter ? 1 : 0, cast(LPARAM)hInsert);
 }
 
 /**
@@ -4113,7 +4113,7 @@ void setItemCount (int count, HANDLE hParent, HANDLE hItem) {
     }
     int itemCount = 0;
     while (hItem !is null && itemCount < count) {
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
         itemCount++;
     }
     bool expanded = false;
@@ -4123,7 +4123,7 @@ void setItemCount (int count, HANDLE hParent, HANDLE hItem) {
         if (OS.IsWinCE) {
             tvItem.hItem = cast(HTREEITEM)hParent;
             tvItem.mask = OS.TVIF_STATE;
-            OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
             expanded = (tvItem.state & OS.TVIS_EXPANDED) !is 0;
         } else {
             /*
@@ -4132,14 +4132,14 @@ void setItemCount (int count, HANDLE hParent, HANDLE hItem) {
             * with TVIS_EXPANDED, the entire state is returned.  The fix is
             * to explicitly check for the TVIS_EXPANDED bit.
             */
-            auto state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hParent, OS.TVIS_EXPANDED);
+            auto state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hParent, OS.TVIS_EXPANDED);
             expanded = (state & OS.TVIS_EXPANDED) !is 0;
         }
     }
     while (hItem !is null) {
         tvItem.hItem = cast(HTREEITEM)hItem;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
         TreeItem item = tvItem.lParam !is -1 ? items [tvItem.lParam] : null;
         if (item !is null && !item.isDisposed ()) {
             item.dispose ();
@@ -4223,10 +4223,10 @@ override HWND scrolledHandle () {
 void select (HANDLE hItem, TVITEM* tvItem) {
     while (hItem !is null) {
         tvItem.hItem = cast(HTREEITEM)hItem;
-        OS.SendMessage (handle, OS.TVM_SETITEM, 0, tvItem);
-        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)tvItem);
+        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
         select (hFirstItem, tvItem);
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
     }
 }
 
@@ -4261,7 +4261,7 @@ public void select (TreeItem item) {
             OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
             state = tvItem.state;
         } else {
-            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, &hItem, OS.TVIS_SELECTED);
+            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)&hItem, OS.TVIS_SELECTED);
         }
         if ((state & OS.TVIS_SELECTED) !is 0) return;
         /*
@@ -4315,7 +4315,7 @@ public void select (TreeItem item) {
     tvItem.stateMask = OS.TVIS_SELECTED;
     tvItem.state = OS.TVIS_SELECTED;
     tvItem.hItem = cast(HTREEITEM)item.handle;
-    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
 }
 
 /**
@@ -4346,7 +4346,7 @@ public void selectAll () {
             TreeItem item = items [i];
             if (item !is null) {
                 tvItem.hItem = cast(HTREEITEM)item.handle;
-                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             }
         }
     }
@@ -4551,7 +4551,7 @@ public void setColumnOrder (int [] order) {
     }
     if (order.length !is columnCount) error (SWT.ERROR_INVALID_ARGUMENT);
     int [] oldOrder = new int [columnCount];
-    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, oldOrder.ptr);
+    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)oldOrder.ptr);
     bool reorder = false;
     bool [] seen = new bool [columnCount];
     for (int i=0; i<order.length; i++) {
@@ -4565,9 +4565,9 @@ public void setColumnOrder (int [] order) {
         RECT [] oldRects = new RECT [columnCount];
         for (int i=0; i<columnCount; i++) {
             //oldRects [i] = new RECT ();
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, & oldRects [i]);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)& oldRects [i]);
         }
-        OS.SendMessage (hwndHeader, OS.HDM_SETORDERARRAY, order.length, order.ptr);
+        OS.SendMessage (hwndHeader, OS.HDM_SETORDERARRAY, order.length, cast(LPARAM)order.ptr);
         OS.InvalidateRect (handle, null, true);
         updateImageList ();
         TreeColumn [] newColumns = new TreeColumn [columnCount];
@@ -4576,7 +4576,7 @@ public void setColumnOrder (int [] order) {
         for (int i=0; i<columnCount; i++) {
             TreeColumn column = newColumns [i];
             if (!column.isDisposed ()) {
-                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &newRect);
+                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&newRect);
                 if (newRect.left !is oldRects [i].left) {
                     column.updateToolTip (i);
                     column.sendEvent (SWT.Move);
@@ -4676,7 +4676,7 @@ void setCheckboxImageList () {
     }
     OS.DeleteObject (hBitmap);
     auto hOldStateList = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_STATE, 0);
-    OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_STATE, hStateList);
+    OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_STATE, cast(LPARAM)hStateList);
     if (hOldStateList !is null) OS.ImageList_Destroy (hOldStateList);
 }
 
@@ -4767,7 +4767,7 @@ override public void setRedraw (bool redraw) {
             if (count is 0) {
                 TVINSERTSTRUCT tvInsert;
                 tvInsert.hInsertAfter = cast(HTREEITEM) OS.TVI_FIRST;
-                hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_INSERTITEM, 0, &tvInsert);
+                hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_INSERTITEM, 0, cast(LPARAM)&tvInsert);
             }
             OS.DefWindowProc (handle, OS.WM_SETREDRAW, 1, 0);
             updateScrollBar ();
@@ -4779,7 +4779,7 @@ override public void setRedraw (bool redraw) {
     }
     if (hItem !is null) {
         ignoreShrink = true;
-        OS.SendMessage (handle, OS.TVM_DELETEITEM, 0, hItem);
+        OS.SendMessage (handle, OS.TVM_DELETEITEM, 0, cast(LPARAM)hItem);
         ignoreShrink = false;
     }
 }
@@ -4790,7 +4790,7 @@ void setScrollWidth () {
     HDITEM hdItem;
     for (int i=0; i<columnCount; i++) {
         hdItem.mask = OS.HDI_WIDTH;
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, i, &hdItem);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEM, i, cast(LPARAM)&hdItem);
         width += hdItem.cxy;
     }
     setScrollWidth (Math.max (scrollWidth, width));
@@ -4834,7 +4834,7 @@ void setScrollWidth (int width) {
     playout.prc = &layoutrect;
     WINDOWPOS pos;
     playout.pwpos = &pos;
-    OS.SendMessage (hwndHeader, OS.HDM_LAYOUT, 0, &playout);
+    OS.SendMessage (hwndHeader, OS.HDM_LAYOUT, 0, cast(LPARAM)&playout);
     SetWindowPos (hwndHeader, cast(HWND)OS.HWND_TOP, pos.x - left, pos.y, pos.cx + left, pos.cy, OS.SWP_NOACTIVATE);
     int bits = OS.GetWindowLong (handle, OS.GWL_EXSTYLE);
     int b = (bits & OS.WS_EX_CLIENTEDGE) !is 0 ? OS.GetSystemMetrics (OS.SM_CXEDGE) : 0;
@@ -4855,21 +4855,21 @@ void setSelection (HANDLE hItem, TVITEM* tvItem, TreeItem [] selection) {
             index++;
         }
         tvItem.hItem = cast(HTREEITEM)hItem;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         if ((tvItem.state & OS.TVIS_SELECTED) !is 0) {
             if (index is selection.length) {
                 tvItem.state = 0;
-                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             }
         } else {
             if (index !is selection.length) {
                 tvItem.state = OS.TVIS_SELECTED;
-                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             }
         }
-        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+        auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
         setSelection (hFirstItem, tvItem, selection);
-        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXT, cast(LPARAM)hItem);
     }
 }
 
@@ -4955,11 +4955,11 @@ public void setSelection (TreeItem [] items) {
             OS.DefWindowProc (handle, OS.WM_SETREDRAW, 0, 0);
         }
         ignoreSelect = true;
-        OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, hNewItem);
+        OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, cast(LPARAM)hNewItem);
         ignoreSelect = false;
         if (OS.SendMessage (handle, OS.TVM_GETVISIBLECOUNT, 0, 0) is 0) {
-            OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, hNewItem);
-            auto hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hNewItem);
+            OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, cast(LPARAM)hNewItem);
+            auto hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hNewItem);
             if (hParent is 0) OS.SendMessage (handle, OS.WM_HSCROLL, OS.SB_TOP, 0);
         }
         if (fixScroll) {
@@ -4980,7 +4980,7 @@ public void setSelection (TreeItem [] items) {
             tvItem.state = OS.TVIS_SELECTED;
             tvItem.stateMask = OS.TVIS_SELECTED;
             tvItem.hItem = cast(HTREEITEM)hNewItem;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             showItem (hNewItem);
         }
     }
@@ -5005,16 +5005,16 @@ public void setSelection (TreeItem [] items) {
                     index++;
                 }
                 tvItem.hItem = cast(HTREEITEM)item.handle;
-                OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                 if ((tvItem.state & OS.TVIS_SELECTED) !is 0) {
                     if (index is length) {
                         tvItem.state = 0;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     }
                 } else {
                     if (index !is length) {
                         tvItem.state = OS.TVIS_SELECTED;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     }
                 }
             }
@@ -5109,8 +5109,8 @@ public void setTopItem (TreeItem item) {
         redraw = drawCount is 0 && OS.IsWindowVisible (handle);
         if (redraw) OS.DefWindowProc (handle, OS.WM_SETREDRAW, 0, 0);
     }
-    OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, hItem);
-    auto hParent = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hItem);
+    OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, cast(LPARAM)hItem);
+    auto hParent = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hItem);
     if (hParent is null) OS.SendMessage (handle, OS.WM_HSCROLL, OS.SB_TOP, 0);
     if (fixScroll) {
         OS.DefWindowProc (handle, OS.WM_SETREDRAW, 1, 0);
@@ -5140,7 +5140,7 @@ void showItem (HANDLE hItem) {
             OS.SendMessage (handle, OS.WM_SETREDRAW, 1, 0);
             OS.DefWindowProc (handle, OS.WM_SETREDRAW, 0, 0);
         }
-        OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, hItem);
+        OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, cast(LPARAM)hItem);
         /* This code is intentionally commented */
         //auto hParent = OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hItem);
         //if (hParent is 0) OS.SendMessage (handle, OS.WM_HSCROLL, OS.SB_TOP, 0);
@@ -5170,7 +5170,7 @@ void showItem (HANDLE hItem) {
                 OS.SendMessage (handle, OS.WM_SETREDRAW, 1, 0);
                 OS.DefWindowProc (handle, OS.WM_SETREDRAW, 0, 0);
             }
-            OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, hItem);
+            OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, cast(LPARAM)hItem);
             if (fixScroll) {
                 OS.DefWindowProc (handle, OS.WM_SETREDRAW, 1, 0);
                 OS.SendMessage (handle, OS.WM_SETREDRAW, 0, 0);
@@ -5234,7 +5234,7 @@ public void showColumn (TreeColumn column) {
         OS.GetClientRect (hwndParent, &rect);
         OS.MapWindowPoints (hwndParent, handle, cast(POINT*) &rect, 2);
         RECT headerRect;
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
         bool scroll = headerRect.left < rect.left;
         if (!scroll) {
             int width = Math.min (rect.right - rect.left, headerRect.right - headerRect.left);
@@ -5302,7 +5302,7 @@ public void showSelection () {
             OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
             state = tvItem.state;
         } else {
-            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, hItem, OS.TVIS_SELECTED);
+            state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)hItem, OS.TVIS_SELECTED);
         }
         if ((state & OS.TVIS_SELECTED) is 0) return;
     } else {
@@ -5329,7 +5329,7 @@ public void showSelection () {
                         OS.SendMessage (handle, OS.TVM_GETITEM, 0, tvItem);
                         state = tvItem.state;
                     } else {
-                        state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, item.handle, OS.TVIS_SELECTED);
+                        state = OS.SendMessage (handle, OS.TVM_GETITEMSTATE, cast(WPARAM)item.handle, OS.TVIS_SELECTED);
                     }
                     if ((state & OS.TVIS_SELECTED) !is 0) {
                         hItem = item.handle;
@@ -5356,7 +5356,7 @@ void sort (HANDLE hParent, bool all) {
     hFirstIndexOf = hLastIndexOf = null;
     itemCount = -1;
     if (sortDirection is SWT.UP || sortDirection is SWT.NONE) {
-        OS.SendMessage (handle, OS.TVM_SORTCHILDREN, all ? 1 : 0, hParent);
+        OS.SendMessage (handle, OS.TVM_SORTCHILDREN, all ? 1 : 0, cast(LPARAM)hParent);
     } else {
         //Callback compareCallback = new Callback (this, "CompareFunc", 3);
         //int lpfnCompare = compareCallback.getAddress ();
@@ -5365,7 +5365,7 @@ void sort (HANDLE hParent, bool all) {
         psort.hParent = cast(HTREEITEM)hParent;
         psort.lpfnCompare = &CompareFunc;
         psort.lParam = sortColumn is null ? 0 : indexOf (sortColumn);
-        OS.SendMessage (handle, OS.TVM_SORTCHILDRENCB, all ? 1 : 0, &psort);
+        OS.SendMessage (handle, OS.TVM_SORTCHILDRENCB, all ? 1 : 0, cast(LPARAM)&psort);
         sThis = null;
         //compareCallback.dispose ();
     }
@@ -5472,13 +5472,13 @@ void updateHeaderToolTips () {
     lpti.lpszText = OS.LPSTR_TEXTCALLBACK;
     for (int i=0; i<columnCount; i++) {
         TreeColumn column = columns [i];
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, &rect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, i, cast(LPARAM)&rect) !is 0) {
             lpti.uId = column.id = display.nextToolTipId++;
             lpti.rect.left = rect.left;
             lpti.rect.top = rect.top;
             lpti.rect.right = rect.right;
             lpti.rect.bottom = rect.bottom;
-            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, &lpti);
+            OS.SendMessage (headerToolTipHandle, OS.TTM_ADDTOOL, 0, cast(LPARAM)&lpti);
         }
     }
 }
@@ -5509,7 +5509,7 @@ void updateImageList () {
     HBITMAP hImageList = i is items.length ? null : imageList.getHandle ();
     HANDLE hOldImageList = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETIMAGELIST, OS.TVSIL_NORMAL, 0);
     if (hImageList !is hOldImageList) {
-        OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, hImageList);
+        OS.SendMessage (handle, OS.TVM_SETIMAGELIST, OS.TVSIL_NORMAL, cast(LPARAM)hImageList);
     }
 }
 
@@ -5662,7 +5662,7 @@ override .LRESULT windowProc (HWND hwnd, int msg, WPARAM wParam, LPARAM lParam) 
                         OS.ScreenToClient (hwnd, &pt);
                         pinfo.pt.x = pt.x;
                         pinfo.pt.y = pt.y;
-                        auto index = OS.SendMessage (hwndHeader, OS.HDM_HITTEST, 0, &pinfo);
+                        auto index = OS.SendMessage (hwndHeader, OS.HDM_HITTEST, 0, cast(LPARAM)&pinfo);
                         if (0 <= index && index < columnCount && !columns [index].resizable) {
                             if ((pinfo.flags & (OS.HHT_ONDIVIDER | OS.HHT_ONDIVOPEN)) !is 0) {
                                 OS.SetCursor (OS.LoadCursor (null, cast(TCHAR*) OS.IDC_ARROW));
@@ -5842,7 +5842,7 @@ override .LRESULT windowProc (HWND hwnd, int msg, WPARAM wParam, LPARAM lParam) 
             if ((style & SWT.MIRRORED) !is 0) {
                 shdi.ptOffset.x = shdi.sizeDragImage.cx - shdi.ptOffset.x; 
             }
-            OS.MoveMemory (lParam, &shdi, SHDRAGIMAGE.sizeof);
+            OS.MoveMemory (cast(LPVOID)lParam, &shdi, SHDRAGIMAGE.sizeof);
             return 1;
         }
     }
@@ -5866,13 +5866,13 @@ override LRESULT WM_CHAR (WPARAM wParam, LPARAM lParam) {
             HANDLE hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CARET, 0);
             if (hItem !is null) {
                 hAnchor = hItem;
-                OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, hItem);
+                OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, cast(LPARAM)hItem);
                 TVITEM tvItem;
                 tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE | OS.TVIF_PARAM;
                 tvItem.hItem = cast(HTREEITEM)hItem;
                 if ((style & SWT.CHECK) !is 0) {
                     tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
-                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                     int state = tvItem.state >> 12;
                     if ((state & 0x1) !is 0) {
                         state++;
@@ -5880,17 +5880,17 @@ override LRESULT WM_CHAR (WPARAM wParam, LPARAM lParam) {
                         --state;
                     }
                     tvItem.state = state << 12;
-                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     static if (!OS.IsWinCE) {
                         auto id = cast(int)/*64bit*/hItem;
                         if (OS.COMCTL32_MAJOR >= 6) {
-                            id = cast(int)/*64bit*/OS.SendMessage (handle, OS.TVM_MAPHTREEITEMTOACCID, hItem, 0);
+                            id = cast(int)/*64bit*/OS.SendMessage (handle, OS.TVM_MAPHTREEITEMTOACCID, cast(WPARAM)hItem, 0);
                         }
                         OS.NotifyWinEvent (OS.EVENT_OBJECT_FOCUS, handle, OS.OBJID_CLIENT, id);
                     }
                 }
                 tvItem.stateMask = OS.TVIS_SELECTED;
-                OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                 if ((style & SWT.MULTI) !is 0 && OS.GetKeyState (OS.VK_CONTROL) < 0) {
                     if ((tvItem.state & OS.TVIS_SELECTED) !is 0) {
                         tvItem.state &= ~OS.TVIS_SELECTED;
@@ -5900,7 +5900,7 @@ override LRESULT WM_CHAR (WPARAM wParam, LPARAM lParam) {
                 } else {
                     tvItem.state |= OS.TVIS_SELECTED;
                 }
-                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                 TreeItem item = _getItem (hItem, tvItem.lParam);
                 Event event = new Event ();
                 event.item = item;
@@ -6034,8 +6034,8 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
                     int flags = rect1.top < rect2.top ? OS.TVGN_PREVIOUSVISIBLE : OS.TVGN_NEXTVISIBLE;
                     while (hDeselectItem !is hAnchor) {
                         tvItem.hItem = cast(HTREEITEM)hDeselectItem;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
-                        hDeselectItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, flags, hDeselectItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
+                        hDeselectItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, flags, cast(LPARAM)hDeselectItem);
                     }
                     auto hSelectItem = hAnchor;
                     OS.TreeView_GetItemRect (handle, cast(HTREEITEM)hNewItem, &rect1, false);
@@ -6044,14 +6044,14 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
                     flags = rect1.top < rect2.top ? OS.TVGN_PREVIOUSVISIBLE : OS.TVGN_NEXTVISIBLE;
                     while (hSelectItem !is hNewItem) {
                         tvItem.hItem = cast(HTREEITEM)hSelectItem;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
-                        hSelectItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, flags, hSelectItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
+                        hSelectItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, flags, cast(LPARAM)hSelectItem);
                     }
                     tvItem.hItem = cast(HTREEITEM)hNewItem;
-                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
                     tvItem.hItem = cast(HTREEITEM)hNewItem;
-                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                     Event event = new Event ();
                     event.item = _getItem (hNewItem, tvItem.lParam);
                     postEvent (SWT.Selection, event);
@@ -6065,15 +6065,15 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
                     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
                     tvItem.stateMask = OS.TVIS_SELECTED;
                     tvItem.hItem = cast(HTREEITEM)hItem;
-                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                     bool oldSelected = (tvItem.state & OS.TVIS_SELECTED) !is 0;
                     HANDLE hNewItem;
                     switch (wParam) {
                         case OS.VK_UP:
-                            hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUSVISIBLE, hItem);
+                            hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PREVIOUSVISIBLE, cast(LPARAM)hItem);
                             break;
                         case OS.VK_DOWN:
-                            hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hItem);
+                            hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hItem);
                             break;
                         case OS.VK_HOME:
                             hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_ROOT, 0);
@@ -6090,7 +6090,7 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
                             OS.GetClientRect (handle, &clientRect);
                             hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_FIRSTVISIBLE, 0);
                             do {
-                                auto hVisible = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hNewItem);
+                                auto hVisible = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hNewItem);
                                 if (hVisible is null) break;
                                 if (!OS.TreeView_GetItemRect (handle, cast(HTREEITEM)hVisible, &rect, false)) break;
                                 if (rect.bottom > clientRect.bottom) break;
@@ -6105,9 +6105,9 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
                         default:
                     }
                     if (hNewItem !is null) {
-                        OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, hNewItem);
+                        OS.SendMessage (handle, OS.TVM_ENSUREVISIBLE, 0, cast(LPARAM)hNewItem);
                         tvItem.hItem = cast(HTREEITEM)hNewItem;
-                        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                         bool newSelected = (tvItem.state & OS.TVIS_SELECTED) !is 0;
                         bool redraw = !newSelected && drawCount is 0 && OS.IsWindowVisible (handle);
                         if (redraw) {
@@ -6116,18 +6116,18 @@ override LRESULT WM_KEYDOWN (WPARAM wParam, LPARAM lParam) {
                         }
                         hSelect = hNewItem;
                         ignoreSelect = true;
-                        OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, hNewItem);
+                        OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, cast(LPARAM)hNewItem);
                         ignoreSelect = false;
                         hSelect = null;
                         if (oldSelected) {
                             tvItem.state = OS.TVIS_SELECTED;
                             tvItem.hItem = cast(HTREEITEM)hItem;
-                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                         }
                         if (!newSelected) {
                             tvItem.state = 0;
                             tvItem.hItem = cast(HTREEITEM)hNewItem;
-                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                         }
                         if (redraw) {
                             RECT rect1, rect2;
@@ -6188,7 +6188,7 @@ override LRESULT WM_LBUTTONDBLCLK (WPARAM wParam, LPARAM lParam) {
     TVHITTESTINFO lpht;
     lpht.pt.x = OS.GET_X_LPARAM (lParam);
     lpht.pt.y = OS.GET_Y_LPARAM (lParam);
-    OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+    OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
     if (lpht.hItem !is null) {
         if ((style & SWT.CHECK) !is 0) {
             if ((lpht.flags & OS.TVHT_ONITEMSTATEICON) !is 0) {
@@ -6209,7 +6209,7 @@ override LRESULT WM_LBUTTONDBLCLK (WPARAM wParam, LPARAM lParam) {
                 tvItem.hItem = lpht.hItem;
                 tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM | OS.TVIF_STATE;
                 tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
-                OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                 int state = tvItem.state >> 12;
                 if ((state & 0x1) !is 0) {
                     state++;
@@ -6217,11 +6217,11 @@ override LRESULT WM_LBUTTONDBLCLK (WPARAM wParam, LPARAM lParam) {
                     --state;
                 }
                 tvItem.state = state << 12;
-                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                 static if (!OS.IsWinCE) {
                     int id = cast(int)/*64bit*/tvItem.hItem;
                     if (OS.COMCTL32_MAJOR >= 6) {
-                        id = cast(int)/*64bit*/OS.SendMessage (handle, OS.TVM_MAPHTREEITEMTOACCID, tvItem.hItem, 0);
+                        id = cast(int)/*64bit*/OS.SendMessage (handle, OS.TVM_MAPHTREEITEMTOACCID, cast(WPARAM)tvItem.hItem, 0);
                     }
                     OS.NotifyWinEvent (OS.EVENT_OBJECT_FOCUS, handle, OS.OBJID_CLIENT, id);
                 }
@@ -6267,7 +6267,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
     TVHITTESTINFO lpht;
     lpht.pt.x = OS.GET_X_LPARAM (lParam);
     lpht.pt.y = OS.GET_Y_LPARAM (lParam);
-    OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+    OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
     if (lpht.hItem is null || (lpht.flags & OS.TVHT_ONITEMBUTTON) !is 0) {
         Display display = this.display;
         display.captureChanged = false;
@@ -6284,21 +6284,21 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                 TVITEM tvItem;
                 tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
                 tvItem.hItem = lpht.hItem;
-                OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                 if ((tvItem.state & OS.TVIS_EXPANDED) !is 0) {
                     fixSelection = true;
                     tvItem.stateMask = OS.TVIS_SELECTED;
-                    auto hNext = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, lpht.hItem);
+                    auto hNext = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)lpht.hItem);
                     while (hNext !is null) {
                         if (hNext is hAnchor) hAnchor = null;
                         tvItem.hItem = cast(HTREEITEM)hNext;
-                        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                         if ((tvItem.state & OS.TVIS_SELECTED) !is 0) deselected = true;
                         tvItem.state = 0;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
-                        HANDLE hItem = hNext = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hNext);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
+                        HANDLE hItem = hNext = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hNext);
                         while (hItem !is null && hItem !is lpht.hItem) {
-                            hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hItem);
+                            hItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hItem);
                         }
                         if (hItem is null) break;
                     }
@@ -6370,7 +6370,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
             tvItem.hItem = lpht.hItem;
             tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM | OS.TVIF_STATE;
             tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
-            OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
             int state = tvItem.state >> 12;
             if ((state & 0x1) !is 0) {
                 state++;
@@ -6378,11 +6378,11 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                 --state;
             }
             tvItem.state = state << 12;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
             static if (!OS.IsWinCE) {
                 int id = cast(int)/*64bit*/tvItem.hItem;
                 if (OS.COMCTL32_MAJOR >= 6) {
-                    id = cast(int)/*64bit*/OS.SendMessage (handle, OS.TVM_MAPHTREEITEMTOACCID, tvItem.hItem, 0);
+                    id = cast(int)/*64bit*/OS.SendMessage (handle, OS.TVM_MAPHTREEITEMTOACCID, cast(WPARAM)tvItem.hItem, 0);
                 }
                 OS.NotifyWinEvent (OS.EVENT_OBJECT_FOCUS, handle, OS.OBJID_CLIENT, id);
             }
@@ -6446,7 +6446,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
     bool hittestSelected = false;
     if ((style & SWT.MULTI) !is 0) {
         tvItem.hItem = lpht.hItem;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         hittestSelected = (tvItem.state & OS.TVIS_SELECTED) !is 0;
     }
 
@@ -6454,7 +6454,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
     auto hOldItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CARET, 0);
     if ((style & SWT.MULTI) !is 0) {
         tvItem.hItem = cast(HTREEITEM)hOldItem;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
 
         /* Check for CONTROL or drag selection */
         if (hittestSelected || (wParam & OS.MK_CONTROL) !is 0) {
@@ -6511,7 +6511,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
     auto hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CARET, 0);
     if (fakeSelection) {
         if (hOldItem is null || (hNewItem is hOldItem && lpht.hItem !is hOldItem)) {
-            OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, lpht.hItem);
+            OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, cast(LPARAM)lpht.hItem);
             hNewItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CARET, 0);
         }
         if (!dragStarted && (state & DRAG_DETECT) !is 0 && hooks (SWT.DragDetect)) {
@@ -6540,7 +6540,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
             tvItem.state = OS.TVIS_SELECTED;
             tvItem.stateMask = OS.TVIS_SELECTED;
             tvItem.hItem = cast(HTREEITEM)hNewItem;
-            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
         }
     }
 
@@ -6553,18 +6553,18 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                 if ((wParam & OS.MK_CONTROL) !is 0) {
                     tvItem.state ^= OS.TVIS_SELECTED;
                     if (dragStarted) tvItem.state = OS.TVIS_SELECTED;
-                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                 }
             } else {
                 if ((tvItem.state & OS.TVIS_SELECTED) !is 0) {
                     tvItem.state = OS.TVIS_SELECTED;
-                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                 }
                 if ((wParam & OS.MK_CONTROL) !is 0 && !dragStarted) {
                     if (hittestSelected) {
                         tvItem.state = 0;
                         tvItem.hItem = lpht.hItem;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     }
                 }
             }
@@ -6594,13 +6594,13 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                         TreeItem item = items [i];
                         if (item !is null && item.handle !is hNewItem) {
                             tvItem.hItem = cast(HTREEITEM)item.handle;
-                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                         }
                     }
                 }
                 tvItem.hItem = cast(HTREEITEM)hNewItem;
                 tvItem.state = OS.TVIS_SELECTED;
-                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                 OS.SetWindowLongPtr (handle, OS.GWLP_WNDPROC, oldProc);
                 if ((wParam & OS.MK_SHIFT) !is 0) {
                     RECT rect1;
@@ -6611,11 +6611,11 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                             int flags = rect1.top < rect2.top ? OS.TVGN_NEXTVISIBLE : OS.TVGN_PREVIOUSVISIBLE;
                             tvItem.state = OS.TVIS_SELECTED;
                             auto hItem = tvItem.hItem = cast(HTREEITEM)hAnchor;
-                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                            OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                             while (hItem !is hNewItem) {
                                 tvItem.hItem = hItem;
-                                OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
-                                hItem = cast(HTREEITEM) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, flags, hItem);
+                                OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
+                                hItem = cast(HTREEITEM) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, flags, cast(LPARAM)hItem);
                             }
                         }
                     }
@@ -6629,7 +6629,7 @@ override LRESULT WM_LBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
     if (!gestureCompleted) {
         tvItem.hItem = cast(HTREEITEM)hNewItem;
         tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
-        OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         Event event = new Event ();
         event.item = _getItem (tvItem.hItem, tvItem.lParam);
         postEvent (SWT.Selection, event);
@@ -6698,7 +6698,7 @@ override LRESULT WM_MOUSEMOVE (WPARAM wParam, LPARAM lParam) {
                 lpti.rect.top = cellRect.top;
                 lpti.rect.right = cellRect.right;
                 lpti.rect.bottom = cellRect.bottom;
-                OS.SendMessage (itemToolTipHandle, OS.TTM_NEWTOOLRECT, 0, &lpti);
+                OS.SendMessage (itemToolTipHandle, OS.TTM_NEWTOOLRECT, 0, cast(LPARAM)&lpti);
             }
         }
     }
@@ -6749,7 +6749,7 @@ override LRESULT WM_RBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
     TVHITTESTINFO lpht;
     lpht.pt.x = OS.GET_X_LPARAM (lParam);
     lpht.pt.y = OS.GET_Y_LPARAM (lParam);
-    OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+    OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
     if (lpht.hItem !is null) {
         bool fakeSelection = (style & SWT.FULL_SELECTION) !is 0;
         if (!fakeSelection) {
@@ -6766,12 +6766,12 @@ override LRESULT WM_RBUTTONDOWN (WPARAM wParam, LPARAM lParam) {
                 tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
                 tvItem.stateMask = OS.TVIS_SELECTED;
                 tvItem.hItem = lpht.hItem;
-                OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                 if ((tvItem.state & OS.TVIS_SELECTED) is 0) {
                     ignoreSelect = true;
                     OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, 0);
                     ignoreSelect = false;
-                    OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, lpht.hItem);
+                    OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, cast(LPARAM)lpht.hItem);
                 }
             }
         }
@@ -7117,7 +7117,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                     TVITEM tvItem;
                     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
                     tvItem.hItem = lptvdi.item.hItem;
-                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, &tvItem);
+                    OS.SendMessage (handle, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
                     id = tvItem.lParam;
                 }
             }
@@ -7231,7 +7231,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                 TVHITTESTINFO lpht;
                 lpht.pt.x = pt.x;
                 lpht.pt.y = pt.y;
-                OS.SendMessage (handle, OS.TVM_HITTEST, 0, &lpht);
+                OS.SendMessage (handle, OS.TVM_HITTEST, 0, cast(LPARAM)&lpht);
                 if (lpht.hItem !is null && (lpht.flags & OS.TVHT_ONITEM) !is 0) {
                     return LRESULT.ONE;
                 }
@@ -7292,7 +7292,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                         tvItem.mask = OS.TVIF_STATE;
                         tvItem.stateMask = OS.TVIS_SELECTED;
                         tvItem.state = OS.TVIS_SELECTED;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     }
                     if (!newSelected && ignoreSelect) {
                         if (treeView is null) {
@@ -7302,7 +7302,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                         tvItem.mask = OS.TVIF_STATE;
                         tvItem.stateMask = OS.TVIS_SELECTED;
                         tvItem.state = 0;
-                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, &tvItem);
+                        OS.SendMessage (handle, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
                     }
                 }
             }
@@ -7380,7 +7380,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                 * The fix is to detect this case and run the TVN_ITEMEXPANDED
                 * code in this method.
                 */
-                auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, tvItem.hItem);
+                auto hFirstItem = cast(HANDLE) OS.SendMessage (handle, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)tvItem.hItem);
                 runExpanded = hFirstItem is null;
             }
             if (!runExpanded) break;
@@ -7402,7 +7402,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
             * the insert mark whenever an item is expanded or collapsed.
             */
             if (hInsert !is null) {
-                OS.SendMessage (handle, OS.TVM_SETINSERTMARK, insertAfter ? 1 : 0, hInsert);
+                OS.SendMessage (handle, OS.TVM_SETINSERTMARK, insertAfter ? 1 : 0, cast(LPARAM)hInsert);
             }
             /*
             * Bug in Windows.  When a tree item that has an image
@@ -7442,7 +7442,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
             if (tvItem.hItem !is null && (tvItem.state & OS.TVIS_SELECTED) is 0) {
                 hSelect = tvItem.hItem;
                 ignoreSelect = ignoreDeselect = true;
-                OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, tvItem.hItem);
+                OS.SendMessage (handle, OS.TVM_SELECTITEM, OS.TVGN_CARET, cast(LPARAM)tvItem.hItem);
                 ignoreSelect = ignoreDeselect = false;
                 hSelect = null;
             }
@@ -7547,7 +7547,7 @@ LRESULT wmNotifyHeader (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                 HDITEM* pitem = cast(HDITEM*)phdn.pitem;
                 if ((pitem.mask & OS.HDI_ORDER) !is 0 && pitem.iOrder !is -1) {
                     int [] order = new int [columnCount];
-                    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, order.ptr);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)order.ptr);
                     int index = 0;
                     while (index < order.length) {
                         if (order [index] is phdn.iItem) break;
@@ -7559,9 +7559,9 @@ LRESULT wmNotifyHeader (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                     int end = Math.max (index, pitem.iOrder);
                     RECT rect, headerRect;
                     OS.GetClientRect (handle, &rect);
-                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, order [start], &headerRect);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, order [start], cast(LPARAM)&headerRect);
                     rect.left = Math.max (rect.left, headerRect.left);
-                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, order [end], &headerRect);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, order [end], cast(LPARAM)&headerRect);
                     rect.right = Math.min (rect.right, headerRect.right);
                     OS.InvalidateRect (handle, &rect, true);
                     ignoreColumnMove = false;
@@ -7585,10 +7585,10 @@ LRESULT wmNotifyHeader (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                     OS.GetClientRect (handle, &rect);
                     HDITEM oldItem;
                     oldItem.mask = OS.HDI_WIDTH;
-                    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, phdn.iItem, &oldItem);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, phdn.iItem, cast(LPARAM)&oldItem);
                     int deltaX = newItem.cxy - oldItem.cxy;
                     RECT headerRect;
-                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, phdn.iItem, &headerRect);
+                    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, phdn.iItem, cast(LPARAM)&headerRect);
                     int gridWidth = linesVisible ? GRID_WIDTH : 0;
                     rect.left = headerRect.right - gridWidth;
                     int newX = rect.left + deltaX;
@@ -7639,7 +7639,7 @@ LRESULT wmNotifyHeader (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
                         TreeColumn [] newColumns = new TreeColumn [columnCount];
                         System.arraycopy (columns, 0, newColumns, 0, columnCount);
                         int [] order = new int [columnCount];
-                        OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, order.ptr);
+                        OS.SendMessage (hwndHeader, OS.HDM_GETORDERARRAY, columnCount, cast(LPARAM)order.ptr);
                         bool moved = false;
                         for (int i=0; i<columnCount; i++) {
                             TreeColumn nextColumn = newColumns [order [i]];
@@ -7734,7 +7734,7 @@ LRESULT wmNotifyToolTip (NMTTCUSTOMDRAW* nmcd, LPARAM lParam) {
             if (OS.SendMessage (itemToolTipHandle, OS.TTM_GETCURRENTTOOL, 0, 0) !is 0) {
                 TOOLINFO lpti;
                 lpti.cbSize = OS.TOOLINFO_sizeof;
-                if (OS.SendMessage (itemToolTipHandle, OS.TTM_GETCURRENTTOOL, 0, &lpti) !is 0) {
+                if (OS.SendMessage (itemToolTipHandle, OS.TTM_GETCURRENTTOOL, 0, cast(LPARAM)&lpti) !is 0) {
                     int index;
                     TreeItem item;
                     RECT* cellRect, itemRect;

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TreeColumn.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TreeColumn.d
@@ -327,7 +327,7 @@ public int getWidth () {
     if (hwndHeader is null) return 0;
     HDITEM hdItem;
     hdItem.mask = OS.HDI_WIDTH;
-    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
     return hdItem.cxy;
 }
 
@@ -350,7 +350,7 @@ public void pack () {
     auto hwnd = parent.handle;
     auto hwndHeader = parent.hwndHeader;
     RECT headerRect;
-    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
     auto hDC = OS.GetDC (hwnd);
     HFONT oldFont, newFont = cast(HFONT) OS.SendMessage (hwnd, OS.WM_GETFONT, 0, 0);
     if (newFont !is null) oldFont = OS.SelectObject (hDC, newFont);
@@ -358,7 +358,7 @@ public void pack () {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
     tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_ROOT, 0);
     while (tvItem.hItem !is null) {
-        OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         TreeItem item = tvItem.lParam !is -1 ? parent.items [tvItem.lParam] : null;
         if (item !is null) {
             int itemRight = 0;
@@ -375,7 +375,7 @@ public void pack () {
             }
             columnWidth = Math.max (columnWidth, itemRight - headerRect.left);
         }
-        tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, tvItem.hItem);
+        tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)tvItem.hItem);
     }
     RECT rect;
     int flags = OS.DT_CALCRECT | OS.DT_NOPREFIX;
@@ -500,18 +500,18 @@ public void setAlignment (int alignment) {
     if (hwndHeader is null) return;
     HDITEM hdItem;
     hdItem.mask = OS.HDI_FORMAT;
-    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
     hdItem.fmt &= ~OS.HDF_JUSTIFYMASK;
     if ((style & SWT.LEFT) is SWT.LEFT) hdItem.fmt |= OS.HDF_LEFT;
     if ((style & SWT.CENTER) is SWT.CENTER) hdItem.fmt |= OS.HDF_CENTER;
     if ((style & SWT.RIGHT) is SWT.RIGHT) hdItem.fmt |= OS.HDF_RIGHT;
-    OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
     if (index !is 0) {
         auto hwnd = parent.handle;
         parent.forceResize ();
         RECT rect, headerRect;
         OS.GetClientRect (hwnd, &rect);
-        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+        OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
         rect.left = headerRect.left;
         rect.right = headerRect.right;
         OS.InvalidateRect (hwnd, &rect, true);
@@ -536,7 +536,7 @@ void setImage (Image image, bool sort, bool right) {
     if (hwndHeader is null) return;
     HDITEM hdItem;
     hdItem.mask = OS.HDI_FORMAT | OS.HDI_IMAGE | OS.HDI_BITMAP;
-    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
     hdItem.fmt &= ~OS.HDF_BITMAP_ON_RIGHT;
     if (image !is null) {
         if (sort) {
@@ -555,7 +555,7 @@ void setImage (Image image, bool sort, bool right) {
         hdItem.mask &= ~(OS.HDI_IMAGE | OS.HDI_BITMAP);
         hdItem.fmt &= ~(OS.HDF_IMAGE | OS.HDF_BITMAP);
     }
-    OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
 }
 
 /**
@@ -609,7 +609,7 @@ void setSortDirection (int direction) {
             if (index is -1) return;
             HDITEM hdItem;
             hdItem.mask = OS.HDI_FORMAT | OS.HDI_IMAGE;
-            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_GETITEM, index, cast(LPARAM)&hdItem);
             switch (direction) {
                 case SWT.UP:
                     hdItem.fmt &= ~(OS.HDF_IMAGE | OS.HDF_SORTDOWN);
@@ -633,13 +633,13 @@ void setSortDirection (int direction) {
                     break;
                 default:
             }
-            OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+            OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
             if (OS.COMCTL32_MAJOR >= 6 && OS.IsAppThemed ()) {
                 auto hwnd = parent.handle;
                 parent.forceResize ();
                 RECT rect, headerRect;
                 OS.GetClientRect (hwnd, &rect);
-                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+                OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
                 rect.left = headerRect.left;
                 rect.right = headerRect.right;
                 OS.InvalidateRect (hwnd, &rect, true);
@@ -685,7 +685,7 @@ override public void setText (String string) {
     HDITEM hdItem;
     hdItem.mask = OS.HDI_TEXT;
     hdItem.pszText = pszText;
-    auto result = OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+    auto result = OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
     if (pszText !is null) OS.HeapFree (hHeap, 0, pszText);
     if (result is 0) error (SWT.ERROR_CANNOT_SET_TEXT);
 }
@@ -733,9 +733,9 @@ public void setWidth (int width) {
     HDITEM hdItem;
     hdItem.mask = OS.HDI_WIDTH;
     hdItem.cxy = width;
-    OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, &hdItem);
+    OS.SendMessage (hwndHeader, OS.HDM_SETITEM, index, cast(LPARAM)&hdItem);
     RECT headerRect;
-    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &headerRect);
+    OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&headerRect);
     parent.forceResize ();
     auto hwnd = parent.handle;
     RECT rect;
@@ -750,7 +750,7 @@ void updateToolTip (int index) {
     if (hwndHeaderToolTip !is null) {
         auto hwndHeader = parent.hwndHeader;
         RECT rect;
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, &rect) !is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)&rect) !is 0) {
             TOOLINFO lpti;
             lpti.cbSize = TOOLINFO.sizeof;
             lpti.hwnd = hwndHeader;
@@ -759,7 +759,7 @@ void updateToolTip (int index) {
             lpti.rect.top = rect.top;
             lpti.rect.right = rect.right;
             lpti.rect.bottom = rect.bottom;
-            OS.SendMessage (hwndHeaderToolTip, OS.TTM_NEWTOOLRECT, 0, &lpti);
+            OS.SendMessage (hwndHeaderToolTip, OS.TTM_NEWTOOLRECT, 0, cast(LPARAM)&lpti);
         }
     }
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TreeItem.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TreeItem.d
@@ -236,7 +236,7 @@ static HANDLE findPrevious (TreeItem parentItem, int index) {
     Tree parent = parentItem.parent;
     auto hwnd = parent.handle;
     auto hParent = parentItem.handle;
-    HANDLE hFirstItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hParent);
+    HANDLE hFirstItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hParent);
     HANDLE hItem = parent.findItem (hFirstItem, index - 1);
     if (hItem is null) SWT.error (SWT.ERROR_INVALID_RANGE);
     return hItem;
@@ -258,7 +258,7 @@ void clear () {
         tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
         tvItem.state = 1 << 12;
         tvItem.hItem = cast(HTREEITEM)handle;
-        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     }
     background = foreground = -1;
     font = null;
@@ -293,7 +293,7 @@ void clear () {
 public void clear (int index, bool all) {
     checkWidget ();
     auto hwnd = parent.handle;
-    HANDLE hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    HANDLE hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     if (hItem is null) error (SWT.ERROR_INVALID_RANGE);
     hItem = parent.findItem (hItem, index);
     if (hItem is null) error (SWT.ERROR_INVALID_RANGE);
@@ -301,7 +301,7 @@ public void clear (int index, bool all) {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
     parent.clear (hItem, &tvItem);
     if (all) {
-        hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, hItem);
+        hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)hItem);
         parent.clearAll (hItem, &tvItem, all);
     }
 }
@@ -328,7 +328,7 @@ public void clear (int index, bool all) {
 public void clearAll (bool all) {
     checkWidget ();
     auto hwnd = parent.handle;
-    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     if (hItem is null) return;
     TVITEM tvItem;
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
@@ -446,7 +446,7 @@ RECT* getBounds (int index, bool getText, bool getImage, bool fullText, bool ful
         tvItem.hItem = cast(HTREEITEM)handle;
         tvItem.pszText = OS.LPSTR_TEXTCALLBACK;
         parent.ignoreCustomDraw = true;
-        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
         parent.ignoreCustomDraw = false;
     }
     bool firstColumn = index is 0;
@@ -475,7 +475,7 @@ RECT* getBounds (int index, bool getText, bool getImage, bool fullText, bool ful
             if (hwndHeader !is null) {
                 RECT* headerRect = new RECT();
                 if (columnCount !is 0) {
-                    if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, headerRect) is 0) {
+                    if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)headerRect) is 0) {
                         return new RECT();
                     }
                 } else {
@@ -492,7 +492,7 @@ RECT* getBounds (int index, bool getText, bool getImage, bool fullText, bool ful
     } else {
         if (!(0 <= index && index < columnCount)) return new RECT();
         RECT* headerRect = new RECT();
-        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, headerRect) is 0) {
+        if (OS.SendMessage (hwndHeader, OS.HDM_GETITEMRECT, index, cast(LPARAM)headerRect) is 0) {
             return new RECT();
         }
         if (!OS.TreeView_GetItemRect (hwnd, cast(HTREEITEM)handle, rect, false)) {
@@ -580,7 +580,7 @@ public bool getChecked () {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
     tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
     tvItem.hItem = cast(HTREEITEM)handle;
-    auto result = OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+    auto result = OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
     return (result !is 0) && (((tvItem.state >> 12) & 1) is 0);
 }
 
@@ -613,7 +613,7 @@ public bool getExpanded () {
         * with TVIS_EXPANDED, the entire state is returned.  The fix is
         * to explicitly check for the TVIS_EXPANDED bit.
         */
-        state = OS.SendMessage (hwnd, OS.TVM_GETITEMSTATE, handle, OS.TVIS_EXPANDED);
+        state = OS.SendMessage (hwnd, OS.TVM_GETITEMSTATE, cast(WPARAM)handle, OS.TVIS_EXPANDED);
     }
     return (state & OS.TVIS_EXPANDED) !is 0;
 }
@@ -724,7 +724,7 @@ public bool getGrayed () {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
     tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
     tvItem.hItem = cast(HTREEITEM)handle;
-    auto result = OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+    auto result = OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
     return (result !is 0) && ((tvItem.state >> 12) > 2);
 }
 
@@ -750,7 +750,7 @@ public TreeItem getItem (int index) {
     if (index < 0) error (SWT.ERROR_INVALID_RANGE);
     if (!parent.checkData (this, true)) error (SWT.ERROR_WIDGET_DISPOSED);
     auto hwnd = parent.handle;
-    auto hFirstItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    auto hFirstItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     if (hFirstItem is null) error (SWT.ERROR_INVALID_RANGE);
     auto hItem = parent.findItem (hFirstItem, index);
     if (hItem is null) error (SWT.ERROR_INVALID_RANGE);
@@ -772,7 +772,7 @@ public int getItemCount () {
     checkWidget ();
     if (!parent.checkData (this, true)) error (SWT.ERROR_WIDGET_DISPOSED);
     auto hwnd = parent.handle;
-    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     if (hItem is null) return 0;
     return parent.getItemCount (hItem);
 }
@@ -797,7 +797,7 @@ public TreeItem [] getItems () {
     checkWidget ();
     if (!parent.checkData (this, true)) error (SWT.ERROR_WIDGET_DISPOSED);
     auto hwnd = parent.handle;
-    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     if (hItem is null) return null;
     return parent.getItems (hItem);
 }
@@ -885,7 +885,7 @@ public Tree getParent () {
 public TreeItem getParentItem () {
     checkWidget ();
     auto hwnd = parent.handle;
-    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, handle);
+    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)handle);
     return hItem !is null ? parent._getItem (hItem) : null;
 }
 
@@ -974,7 +974,7 @@ public int indexOf (TreeItem item) {
     if (item is null) error (SWT.ERROR_NULL_ARGUMENT);
     if (item.isDisposed()) error(SWT.ERROR_INVALID_ARGUMENT);
     auto hwnd = parent.handle;
-    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     return hItem is null ? -1 : parent.findIndex (hItem, item.handle);
 }
 
@@ -1049,9 +1049,9 @@ public void removeAll () {
     auto hwnd = parent.handle;
     TVITEM tvItem;
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_PARAM;
-    tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     while (tvItem.hItem !is null) {
-        OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
         TreeItem item = tvItem.lParam !is -1 ? parent.items [tvItem.lParam] : null;
         if (item !is null && !item.isDisposed ()) {
             item.dispose ();
@@ -1059,7 +1059,7 @@ public void removeAll () {
             parent.releaseItem (tvItem.hItem, &tvItem, false);
             parent.destroyItem (null, tvItem.hItem);
         }
-        tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+        tvItem.hItem = cast(HTREEITEM) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     }
 }
 
@@ -1159,7 +1159,7 @@ public void setChecked (bool checked) {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
     tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
     tvItem.hItem = cast(HTREEITEM)handle;
-    OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+    OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
     int state = tvItem.state >> 12;
     if (checked) {
         if ((state & 0x1) !is 0) state++;
@@ -1170,7 +1170,7 @@ public void setChecked (bool checked) {
     if (tvItem.state is state) return;
     if ((parent.style & SWT.VIRTUAL) !is 0) cached = true;
     tvItem.state = state;
-    OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+    OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     /*
     * Bug in Windows.  When TVM_SETITEM is used to set
     * the state image of an item inside TVN_GETDISPINFO,
@@ -1203,7 +1203,7 @@ public void setExpanded (bool expanded) {
 
     /* Do nothing when the item is a leaf or already expanded */
     auto hwnd = parent.handle;
-    if (OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle) is 0) {
+    if (OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle) is 0) {
         return;
     }
     .LRESULT state = 0;
@@ -1220,7 +1220,7 @@ public void setExpanded (bool expanded) {
         * with TVIS_EXPANDED, the entire state is returned.  The fix is
         * to explicitly check for the TVIS_EXPANDED bit.
         */
-        state = OS.SendMessage (hwnd, OS.TVM_GETITEMSTATE, handle, OS.TVIS_EXPANDED);
+        state = OS.SendMessage (hwnd, OS.TVM_GETITEMSTATE, cast(WPARAM)handle, OS.TVIS_EXPANDED);
     }
     if (((state & OS.TVIS_EXPANDED) !is 0) is expanded) return;
 
@@ -1262,7 +1262,7 @@ public void setExpanded (bool expanded) {
                 if (OS.TreeView_GetItemRect (hwnd, cast(HTREEITEM)hItem, &rect, true)) {
                     rects [index++] = rect;
                 }
-                hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, &hItem);
+                hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)&hItem);
             }
             if (noAnimate || hItem !is handle) {
                 redraw = true;
@@ -1301,7 +1301,7 @@ public void setExpanded (bool expanded) {
 
     /* Expand or collapse the item */
     parent.ignoreExpand = true;
-    OS.SendMessage (hwnd, OS.TVM_EXPAND, expanded ? OS.TVE_EXPAND : OS.TVE_COLLAPSE, handle);
+    OS.SendMessage (hwnd, OS.TVM_EXPAND, expanded ? OS.TVE_EXPAND : OS.TVE_COLLAPSE, cast(LPARAM)handle);
     parent.ignoreExpand = false;
 
     /* Scroll back to the top item */
@@ -1310,13 +1310,13 @@ public void setExpanded (bool expanded) {
         if (!expanded) {
             RECT rect;
             while (hTopItem !is null && !OS.TreeView_GetItemRect (hwnd, cast(HTREEITEM)hTopItem, &rect, false)) {
-                hTopItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, hTopItem);
+                hTopItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_PARENT, cast(LPARAM)hTopItem);
                 collapsed = true;
             }
         }
         bool scrolled = true;
         if (hTopItem !is null) {
-            OS.SendMessage (hwnd, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, hTopItem);
+            OS.SendMessage (hwnd, OS.TVM_SELECTITEM, OS.TVGN_FIRSTVISIBLE, cast(LPARAM)hTopItem);
             scrolled = hTopItem !is cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_FIRSTVISIBLE, 0);
         }
         if (!collapsed && !scrolled && oldInfo !is null ) {
@@ -1345,7 +1345,7 @@ public void setExpanded (bool expanded) {
                                 break;
                             }
                         }
-                        hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, hItem);
+                        hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_NEXTVISIBLE, cast(LPARAM)hItem);
                         index++;
                     }
                     fixScroll = index is count && hItem is hBottomItem;
@@ -1440,7 +1440,7 @@ public void setFont (Font font){
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_TEXT;
     tvItem.hItem = cast(HTREEITEM)handle;
     tvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-    OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+    OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
 }
 
 
@@ -1495,7 +1495,7 @@ public void setFont (int index, Font font) {
         tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_TEXT;
         tvItem.hItem = cast(HTREEITEM)handle;
         tvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     } else {
         redraw (index, true, false);
     }
@@ -1599,7 +1599,7 @@ public void setGrayed (bool grayed) {
     tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_STATE;
     tvItem.stateMask = OS.TVIS_STATEIMAGEMASK;
     tvItem.hItem = cast(HTREEITEM)handle;
-    OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, &tvItem);
+    OS.SendMessage (hwnd, OS.TVM_GETITEM, 0, cast(LPARAM)&tvItem);
     int state = tvItem.state >> 12;
     if (grayed) {
         if (state <= 2) state +=2;
@@ -1610,7 +1610,7 @@ public void setGrayed (bool grayed) {
     if (tvItem.state is state) return;
     if ((parent.style & SWT.VIRTUAL) !is 0) cached = true;
     tvItem.state = state;
-    OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+    OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     /*
     * Bug in Windows.  When TVM_SETITEM is used to set
     * the state image of an item inside TVN_GETDISPINFO,
@@ -1716,7 +1716,7 @@ public void setImage (int index, Image image) {
         */
         tvItem.mask |= OS.TVIF_TEXT;
         tvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     } else {
         bool drawText = (image is null && oldImage !is null) || (image !is null && oldImage is null);
         redraw (index, drawText, true);
@@ -1744,7 +1744,7 @@ public void setItemCount (int count) {
     checkWidget ();
     count = Math.max (0, count);
     auto hwnd = parent.handle;
-    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, handle);
+    auto hItem = cast(HANDLE) OS.SendMessage (hwnd, OS.TVM_GETNEXTITEM, OS.TVGN_CHILD, cast(LPARAM)handle);
     parent.setItemCount (count, handle, hItem);
 }
 
@@ -1811,7 +1811,7 @@ public void setText (int index, String string) {
         tvItem.mask = OS.TVIF_HANDLE | OS.TVIF_TEXT;
         tvItem.hItem = cast(HTREEITEM)handle;
         tvItem.pszText = OS.LPSTR_TEXTCALLBACK;
-        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, &tvItem);
+        OS.SendMessage (hwnd, OS.TVM_SETITEM, 0, cast(LPARAM)&tvItem);
     } else {
         redraw (index, true, false);
     }


### PR DESCRIPTION
When trying to compile dwt with ldc, occured errors with this definition:

    extern(Windows):
    LRESULT SendMessageW(HWND, UINT, WPARAM, LPARAM);
    LRESULT SendMessageW(HWND, UINT, void*, LPARAM);
    LRESULT SendMessageW(HWND, UINT, WPARAM, void*);
    LRESULT SendMessageW(HWND, UINT, void*, void*);

WPARAM and LPARAM accept either a integer or a pointer as an argument. Due to the bad design of SendMssage (Win32API), dwt provides several definitions to absorb it. This works correctly because WPARAM, LPARAM, and a pointer are the same size.
However, ldc's decision to prohibit such a declaration because it is dangerous is correct. The solution is to cast a pointer to WPARAM or LPARAM and send to the function.
See also: https://github.com/ldc-developers/ldc/issues/3362

By the way, there was also this declaration:

    void RtlMoveMemory(void* Destination, LPCVOID Source, SIZE_T Length);
    void RtlMoveMemory(intptr_t Destination, LPCVOID Source, SIZE_T Length);
    void RtlMoveMemory(void* Destination, intptr_t Source, SIZE_T Length);
    void RtlMoveMemory(intptr_t Destination, intptr_t Source, SIZE_T Length);

This should be accept a pointer always. The solution is the same.
With these fixes, I confirmed that the dwt application can be compiled and run with ldc.