### PR TITLE
Compatible the specification change of GTK 2.20.0 and 2.22.0

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/gtk.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/gtk.d
@@ -9683,7 +9683,33 @@ alias extern (C) _GtkAccelGroup * function()TGTKgtk_accel_group_new; extern(D) T
 alias extern (C) GType function()TGTKgtk_accel_group_get_type; extern(D) TGTKgtk_accel_group_get_type gtk_accel_group_get_type;
 alias extern (C) GdkWindow* function(GtkWidget*)TGTKgtk_widget_get_window; extern(D) TGTKgtk_widget_get_window gtk_widget_get_window;
 alias extern (C) void function(GtkWidget *, GtkAllocation *)TGTKgtk_widget_get_allocation; extern(D) TGTKgtk_widget_get_allocation gtk_widget_get_allocation;
-alias extern (C) void function(GtkWidget *, const GtkAllocation *)TGTKgtk_widget_set_allocation; extern(D) TGTKgtk_widget_set_allocation gtk_widget_set_allocation;"
+alias extern (C) void function(GtkWidget *, const GtkAllocation *)TGTKgtk_widget_set_allocation; extern(D) TGTKgtk_widget_set_allocation gtk_widget_set_allocation;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_is_toplevel; extern(D) TGTKgtk_widget_is_toplevel gtk_widget_is_toplevel;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_has_window; extern(D) TGTKgtk_widget_get_has_window gtk_widget_get_has_window;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_realized; extern(D) TGTKgtk_widget_get_realized gtk_widget_get_realized;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_mapped; extern(D) TGTKgtk_widget_get_mapped gtk_widget_get_mapped;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_visible; extern(D) TGTKgtk_widget_get_visible gtk_widget_get_visible;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_is_drawable; extern(D) TGTKgtk_widget_is_drawable gtk_widget_is_drawable;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_sensitive; extern(D) TGTKgtk_widget_get_sensitive gtk_widget_get_sensitive;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_is_sensitive; extern(D) TGTKgtk_widget_is_sensitive gtk_widget_is_sensitive;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_can_focus; extern(D) TGTKgtk_widget_get_can_focus gtk_widget_get_can_focus;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_has_focus; extern(D) TGTKgtk_widget_has_focus gtk_widget_has_focus;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_can_default; extern(D) TGTKgtk_widget_get_can_default gtk_widget_get_can_default;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_receives_default; extern(D) TGTKgtk_widget_get_receives_default gtk_widget_get_receives_default;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_has_default; extern(D) TGTKgtk_widget_has_default gtk_widget_has_default;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_has_grab; extern(D) TGTKgtk_widget_has_grab gtk_widget_has_grab;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_has_rc_style; extern(D) TGTKgtk_widget_has_rc_style gtk_widget_has_rc_style;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_app_paintable; extern(D) TGTKgtk_widget_get_app_paintable gtk_widget_get_app_paintable;
+alias extern (C) gboolean function(aGtkWidget *)TGTKgtk_widget_get_double_buffered; extern(D) TGTKgtk_widget_get_double_buffered gtk_widget_get_double_buffered;
+alias extern (C) GtkStateType function(aGtkWidget *)TGTKgtk_widget_get_state; extern(D) TGTKgtk_widget_get_state gtk_widget_get_state;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_has_window; extern(D) TGTKgtk_widget_set_has_window gtk_widget_set_has_window;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_realized; extern(D) TGTKgtk_widget_set_realized gtk_widget_set_realized;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_mapped; extern(D) TGTKgtk_widget_set_mapped gtk_widget_set_mapped;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_visible; extern(D) TGTKgtk_widget_set_visible gtk_widget_set_visible;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_can_focus; extern(D) TGTKgtk_widget_set_can_focus gtk_widget_set_can_focus;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_can_default; extern(D) TGTKgtk_widget_set_can_default gtk_widget_set_can_default;
+alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_receives_default; extern(D) TGTKgtk_widget_set_receives_default gtk_widget_set_receives_default;
+"
 ));
 
 extern(D) Symbol[] symbols;
@@ -13100,7 +13126,32 @@ static this () {
         Symbol( "gtk_widget_set_allocation",  cast(void**)& gtk_widget_set_allocation),
         Symbol( "gtk_scrolled_window_get_hscrollbar",  cast(void**)& gtk_scrolled_window_get_hscrollbar),
         Symbol( "gtk_scrolled_window_get_vscrollbar",  cast(void**)& gtk_scrolled_window_get_vscrollbar),
-        Symbol( "gtk_widget_set_tooltip_window",  cast(void**)& gtk_widget_set_tooltip_window)
+        Symbol( "gtk_widget_set_tooltip_window",  cast(void**)& gtk_widget_set_tooltip_window),
+        Symbol( "gtk_widget_is_toplevel",  cast(void**)& gtk_widget_is_toplevel),
+        Symbol( "gtk_widget_get_has_window",  cast(void**)& gtk_widget_get_has_window),
+        Symbol( "gtk_widget_get_realized",  cast(void**)& gtk_widget_get_realized),
+        Symbol( "gtk_widget_get_mapped",  cast(void**)& gtk_widget_get_mapped),
+        Symbol( "gtk_widget_get_visible",  cast(void**)& gtk_widget_get_visible),
+        Symbol( "gtk_widget_is_drawable",  cast(void**)& gtk_widget_is_drawable),
+        Symbol( "gtk_widget_get_sensitive",  cast(void**)& gtk_widget_get_sensitive),
+        Symbol( "gtk_widget_is_sensitive",  cast(void**)& gtk_widget_is_sensitive),
+        Symbol( "gtk_widget_get_can_focus",  cast(void**)& gtk_widget_get_can_focus),
+        Symbol( "gtk_widget_has_focus",  cast(void**)& gtk_widget_has_focus),
+        Symbol( "gtk_widget_get_can_default",  cast(void**)& gtk_widget_get_can_default),
+        Symbol( "gtk_widget_get_receives_default",  cast(void**)& gtk_widget_get_receives_default),
+        Symbol( "gtk_widget_has_default",  cast(void**)& gtk_widget_has_default),
+        Symbol( "gtk_widget_has_grab",  cast(void**)& gtk_widget_has_grab),
+        Symbol( "gtk_widget_has_rc_style",  cast(void**)& gtk_widget_has_rc_style),
+        Symbol( "gtk_widget_get_app_paintable",  cast(void**)& gtk_widget_get_app_paintable),
+        Symbol( "gtk_widget_get_double_buffered,",  cast(void**)& gtk_widget_get_double_buffered),
+        Symbol( "gtk_widget_get_state,",  cast(void**)& gtk_widget_get_state),
+        Symbol( "gtk_widget_set_has_window",  cast(void**)& gtk_widget_set_has_window),
+        Symbol( "gtk_widget_set_realized",  cast(void**)& gtk_widget_set_realized),
+        Symbol( "gtk_widget_set_mapped",  cast(void**)& gtk_widget_set_mapped),
+        Symbol( "gtk_widget_set_visible",  cast(void**)& gtk_widget_set_visible),
+        Symbol( "gtk_widget_set_can_focus",  cast(void**)& gtk_widget_set_can_focus),
+        Symbol( "gtk_widget_set_can_default",  cast(void**)& gtk_widget_set_can_default),
+        Symbol( "gtk_widget_set_receives_default",  cast(void**)& gtk_widget_set_receives_default),
     ];
 }
 
@@ -16519,5 +16570,30 @@ extern (C) void gtk_widget_set_allocation(GtkWidget *, const GtkAllocation *);
 extern (C) GtkWidget * gtk_scrolled_window_get_hscrollbar(GtkScrolledWindow *);
 extern (C) GtkWidget * gtk_scrolled_window_get_vscrollbar(GtkScrolledWindow *);
 extern (C) void gtk_widget_set_tooltip_window(GtkWidget *, GtkWindow *);
+extern (C) gboolean gtk_widget_is_toplevel(GtkWidget *);
+extern (C) gboolean gtk_widget_get_has_window(GtkWidget *);
+extern (C) gboolean gtk_widget_get_realized(GtkWidget *);
+extern (C) gboolean gtk_widget_get_mapped(GtkWidget *);
+extern (C) gboolean gtk_widget_get_visible(GtkWidget *);
+extern (C) gboolean gtk_widget_is_drawable(GtkWidget *);
+extern (C) gboolean gtk_widget_get_sensitive(GtkWidget *);
+extern (C) gboolean gtk_widget_is_sensitive(GtkWidget *);
+extern (C) gboolean gtk_widget_get_can_focus(GtkWidget *);
+extern (C) gboolean gtk_widget_has_focus(GtkWidget *);
+extern (C) gboolean gtk_widget_get_can_default(GtkWidget *);
+extern (C) gboolean gtk_widget_get_receives_default(GtkWidget *);
+extern (C) gboolean gtk_widget_has_default(GtkWidget *);
+extern (C) gboolean gtk_widget_has_grab(GtkWidget *);
+extern (C) gboolean gtk_widget_has_rc_style(GtkWidget *);
+extern (C) gboolean gtk_widget_get_app_paintable(GtkWidget *);
+extern (C) gboolean gtk_widget_get_double_buffered(GtkWidget *);
+extern (C) GtkStateType gtk_widget_get_state(GtkWidget *);
+extern (C) void gtk_widget_set_has_window(GtkWidget *, gboolean);
+extern (C) void gtk_widget_set_realized(GtkWidget *, gboolean);
+extern (C) void gtk_widget_set_mapped(GtkWidget *, gboolean);
+extern (C) void gtk_widget_set_visible(GtkWidget *, gboolean);
+extern (C) void gtk_widget_set_can_focus(GtkWidget *, gboolean);
+extern (C) void gtk_widget_set_can_default(GtkWidget *, gboolean);
+extern (C) void gtk_widget_set_receives_default(GtkWidget *, gboolean);
 } // version(DYNLINK)
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/gtk/OS.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/gtk/OS.d
@@ -2196,6 +2196,31 @@ public static const int PictOpOver = 3;
     mixin ForwardGtkOsCFunc!(.gtk_scrolled_window_get_hscrollbar);
     mixin ForwardGtkOsCFunc!(.gtk_scrolled_window_get_vscrollbar);
     mixin ForwardGtkOsCFunc!(.gtk_widget_set_tooltip_window);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_is_toplevel);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_has_window);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_realized);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_mapped);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_visible);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_is_drawable);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_sensitive);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_is_sensitive);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_can_focus);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_has_focus);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_can_default);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_receives_default);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_has_default);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_has_grab);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_has_rc_style);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_app_paintable);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_double_buffered);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_get_state);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_has_window);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_realized);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_mapped);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_visible);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_can_focus);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_can_default);
+    mixin ForwardGtkOsCFunc!(.gtk_widget_set_receives_default);
     mixin ForwardGtkOsCFunc!(.pango_attr_background_new );
     mixin ForwardGtkOsCFunc!(.pango_attr_font_desc_new);
     mixin ForwardGtkOsCFunc!(.pango_attr_foreground_new );
@@ -2650,6 +2675,33 @@ public static const int PictOpOver = 3;
 
     static guint GTK_WIDGET_FLAGS( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            guint flags = 0;
+            if (gtk_widget_is_toplevel(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_TOPLEVEL;
+            if (!gtk_widget_get_has_window(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_NO_WINDOW;
+            if (gtk_widget_get_realized(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_REALIZED;
+            if (gtk_widget_get_mapped(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_MAPPED;
+            if (gtk_widget_get_visible(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_VISIBLE;
+            //if (gtk_widget_is_drawable(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_DRAWABLE;
+            if (gtk_widget_get_sensitive(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_SENSITIVE;
+            if (auto parent = OS.gtk_widget_get_parent(cast(GtkWidget*)arg0)) {
+                if (gtk_widget_get_sensitive(parent)) flags |= GtkWidgetFlags.GTK_PARENT_SENSITIVE;
+            }
+            //if (gtk_widget_is_sensitive(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_IS_SENSITIVE;
+            if (gtk_widget_get_can_focus(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_CAN_FOCUS;
+            if (gtk_widget_has_focus(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_HAS_FOCUS;
+            if (gtk_widget_get_can_default(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_CAN_DEFAULT;
+            if (gtk_widget_get_receives_default(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_RECEIVES_DEFAULT;
+            if (gtk_widget_has_default(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_HAS_DEFAULT;
+            if (gtk_widget_has_grab(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_HAS_GRAB;
+            if (gtk_widget_has_rc_style(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_RC_STYLE;
+            //GValue gvalue;
+            //gtk_widget_style_get_property(cast(GtkWidget*)arg0, "composite-child".ptr, &gvalue);
+            //if (g_value_get_boolean(&gvalue)) flags |= GtkWidgetFlags.GTK_COMPOSITE_CHILD;
+            if (gtk_widget_get_app_paintable(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_APP_PAINTABLE;
+            //if (gtk_widget_get_double_buffered(cast(GtkWidget*)arg0)) flags |= GtkWidgetFlags.GTK_DOUBLE_BUFFERED;
+            return flags;
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return    (cast(GtkObject*) g_type_check_instance_cast (cast(GTypeInstance*) arg0,  gtk_object_get_type ())).flags ;
@@ -2657,6 +2709,9 @@ public static const int PictOpOver = 3;
 
     static ubyte GTK_WIDGET_STATE( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(ubyte)gtk_widget_get_state(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return (  cast(GtkWidget*) g_type_check_instance_cast (cast(GTypeInstance*)arg0, gtk_widget_get_type ())).state;
@@ -2664,6 +2719,9 @@ public static const int PictOpOver = 3;
 
     static bool GTK_WIDGET_HAS_DEFAULT( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(bool)gtk_widget_has_default(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return ( ( ( cast(GtkObject*) g_type_check_instance_cast (cast(GTypeInstance*)arg0, gtk_object_get_type () )).flags & GtkWidgetFlags.GTK_HAS_DEFAULT) != 0) ;
@@ -2671,6 +2729,9 @@ public static const int PictOpOver = 3;
 
     static bool GTK_WIDGET_HAS_FOCUS( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(bool)gtk_widget_has_focus(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return ( ( ( cast(GtkObject*) g_type_check_instance_cast (cast(GTypeInstance*)arg0, gtk_object_get_type () )).flags & GtkWidgetFlags.GTK_HAS_FOCUS) != 0) ;
@@ -2678,6 +2739,9 @@ public static const int PictOpOver = 3;
 
     static bool GTK_WIDGET_IS_SENSITIVE( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(bool)gtk_widget_is_sensitive(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return ( ( ( cast (GtkObject*) g_type_check_instance_cast ( cast(GTypeInstance*)arg0, gtk_object_get_type ()) ).flags & GtkWidgetFlags.GTK_SENSITIVE) != 0)   && ( ( ( cast(GtkObject*) g_type_check_instance_cast ( cast(GTypeInstance*)arg0, gtk_object_get_type ()) ).flags & GtkWidgetFlags.GTK_PARENT_SENSITIVE) != 0);
@@ -2685,6 +2749,9 @@ public static const int PictOpOver = 3;
 
     static bool GTK_WIDGET_MAPPED( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(bool)gtk_widget_get_mapped(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return ( ( ( cast(GtkObject*) g_type_check_instance_cast (cast(GTypeInstance*)arg0, gtk_object_get_type () )).flags & GtkWidgetFlags.GTK_MAPPED) != 0) ;
@@ -2692,6 +2759,9 @@ public static const int PictOpOver = 3;
 
     static bool GTK_WIDGET_SENSITIVE( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(bool)gtk_widget_get_sensitive(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return ( ( ( cast(GtkObject*) g_type_check_instance_cast (cast(GTypeInstance*)arg0, gtk_object_get_type () )).flags & GTK_SENSITIVE) != 0) ;
@@ -2699,6 +2769,24 @@ public static const int PictOpOver = 3;
 
     static void GTK_WIDGET_SET_FLAGS( void* arg0, uint arg1 )
     {
+        if (OS.buildVERSION(2, 22, 0) <= OS.GTK_VERSION) {
+            switch (arg1) {
+            case GtkWidgetFlags.GTK_NO_WINDOW: gtk_widget_set_has_window(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_REALIZED: gtk_widget_set_realized(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_MAPPED:  gtk_widget_set_mapped(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_VISIBLE: gtk_widget_set_visible(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_SENSITIVE: gtk_widget_set_sensitive(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_CAN_FOCUS: gtk_widget_set_can_focus(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_HAS_FOCUS: /+ TODO +/ break;
+            case GtkWidgetFlags.GTK_CAN_DEFAULT: gtk_widget_set_can_default(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_RECEIVES_DEFAULT: gtk_widget_set_receives_default(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_APP_PAINTABLE: gtk_widget_set_app_paintable(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_DOUBLE_BUFFERED: gtk_widget_set_double_buffered(cast(GtkWidget*)arg0, true); break;
+            default:
+                implMissing(__FILE__,__LINE__);
+            }
+            return;
+        }
         lock.lock();
         scope(exit) lock.unlock();
         (cast(GtkObject*) g_type_check_instance_cast ( cast(GTypeInstance*)arg0,  gtk_object_get_type () ) ).flags |= arg1;
@@ -2706,6 +2794,24 @@ public static const int PictOpOver = 3;
 
     static void GTK_WIDGET_UNSET_FLAGS( void* arg0, uint arg1 )
     {
+        if (OS.buildVERSION(2, 22, 0) <= OS.GTK_VERSION) {
+            switch (arg1) {
+            case GtkWidgetFlags.GTK_NO_WINDOW: gtk_widget_set_has_window(cast(GtkWidget*)arg0, true); break;
+            case GtkWidgetFlags.GTK_REALIZED: gtk_widget_set_realized(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_MAPPED:  gtk_widget_set_mapped(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_VISIBLE: gtk_widget_set_visible(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_SENSITIVE: gtk_widget_set_sensitive(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_CAN_FOCUS: gtk_widget_set_can_focus(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_HAS_FOCUS: /+ TODO +/ break;
+            case GtkWidgetFlags.GTK_CAN_DEFAULT: gtk_widget_set_can_default(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_RECEIVES_DEFAULT: gtk_widget_set_receives_default(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_APP_PAINTABLE: gtk_widget_set_app_paintable(cast(GtkWidget*)arg0, false); break;
+            case GtkWidgetFlags.GTK_DOUBLE_BUFFERED: gtk_widget_set_double_buffered(cast(GtkWidget*)arg0, false); break;
+            default:
+                implMissing(__FILE__,__LINE__);
+            }
+            return;
+        }
         lock.lock();
         scope(exit) lock.unlock();
         (cast(GtkObject*) g_type_check_instance_cast ( cast(GTypeInstance*)arg0,  gtk_object_get_type () ) ).flags &= ~arg1;
@@ -2713,6 +2819,9 @@ public static const int PictOpOver = 3;
 
     static bool GTK_WIDGET_VISIBLE( void* arg0 )
     {
+        if (OS.buildVERSION(2, 20, 0) <= OS.GTK_VERSION) {
+            return cast(bool)gtk_widget_get_visible(cast(GtkWidget*)arg0);
+        }
         lock.lock();
         scope(exit) lock.unlock();
         return ( ( ( cast(GtkObject*) g_type_check_instance_cast (cast(GTypeInstance*)arg0, gtk_object_get_type () )).flags & GTK_VISIBLE) != 0) ;

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/program/Program.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/program/Program.d
@@ -260,20 +260,20 @@ static int getDesktop(Display display) {
         ptrdiff_t gnome = OS.XInternAtom(xDisplay, gnomeName.ptr, true);
         if (gnome !is OS.None && (OS.GTK_VERSION >= OS.buildVERSION (2, 2, 0)) && gnome_init()) {
             desktop = DESKTOP_GNOME;
-            int icon_theme = cast(int)GNOME.gnome_icon_theme_new();
-            display.setData(ICON_THEME_DATA, new Integer(icon_theme));
+            ptrdiff_t icon_theme = cast(ptrdiff_t)GNOME.gnome_icon_theme_new();
+            display.setData(ICON_THEME_DATA, new Long(icon_theme));
             display.addListener(SWT.Dispose, new class(display) Listener {
                 Display display;
                 this( Display display ){ this.display = display; }
                 public void handleEvent(Event event) {
-                    Integer gnomeIconTheme = cast(Integer)display.getData(ICON_THEME_DATA);
+                    Long gnomeIconTheme = cast(Long)display.getData(ICON_THEME_DATA);
                     if (gnomeIconTheme is null) return;
                     display.setData(ICON_THEME_DATA, null);
                     /*
                      * Note.  gnome_icon_theme_new uses g_object_new to allocate the
                      * data it returns. Use g_object_unref to free the pointer it returns.
                      */
-                    if (gnomeIconTheme.intValue !is 0) OS.g_object_unref( cast(void*)gnomeIconTheme.intValue);
+                    if (gnomeIconTheme.longValue !is 0) OS.g_object_unref( cast(void*)gnomeIconTheme.longValue);
                 }
             });
             /* Check for libgnomevfs-2 version 2.4 */
@@ -685,11 +685,11 @@ static Program gnome_getProgram(Display display, String mimeType) {
         program.gnomeExpectUri = application.expects_uris is GNOME.GNOME_VFS_MIME_APPLICATION_ARGUMENT_TYPE_URIS;
 
         buffer = (fromStringz( application.id) ~ '\0')._idup();
-        Integer gnomeIconTheme = cast(Integer)display.getData(ICON_THEME_DATA);
-        char* icon_name = GNOME.gnome_icon_lookup( cast(GtkIconTheme*) gnomeIconTheme.intValue, null, null, cast(char*)buffer.ptr, null, mimeTypeBuffer,
+        Long gnomeIconTheme = cast(Long)display.getData(ICON_THEME_DATA);
+        char* icon_name = GNOME.gnome_icon_lookup( cast(GtkIconTheme*) gnomeIconTheme.longValue, null, null, cast(char*)buffer.ptr, null, mimeTypeBuffer,
                 GNOME.GNOME_ICON_LOOKUP_FLAGS_NONE, null);
         char* path = null;
-        if (icon_name !is null) path = GNOME.gnome_icon_theme_lookup_icon(cast(GtkIconTheme*)gnomeIconTheme.intValue, icon_name, PREFERRED_ICON_SIZE, null, null);
+        if (icon_name !is null) path = GNOME.gnome_icon_theme_lookup_icon(cast(GtkIconTheme*)gnomeIconTheme.longValue, icon_name, PREFERRED_ICON_SIZE, null, null);
         if (path !is null) {
             program.iconPath = fromStringz( path)._idup();
             OS.g_free(path);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Table.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Table.d
@@ -290,7 +290,7 @@ override void cellDataProc (
                 ptr = null;
                 OS.gtk_tree_model_get1 (tree_model, iter, modelIndex + CELL_BACKGROUND, &ptr);
                 if (ptr !is null) {
-                    OS.g_object_set1 (cell, OS.cell_background_gdk.ptr, cast(int)ptr);
+                    OS.g_object_set1 (cell, OS.cell_background_gdk.ptr, cast(ptrdiff_t)ptr);
                 }
             }
         }


### PR DESCRIPTION
Rewrited a functions that can't be used due to the GTK specification change, I has been successfully ran all snippets with minimal changes.
There are some parts where we do not know if we need to take fix. e.g. `GTK_WIDGET_SET_FLAGS(widget, GTK_HAS_FOCUS)`. However, it works without problems in the range I tried.

By the way, fixed that some pointers were handled as int.