### PR TITLE
Change default shell title from "a" to "".

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Shell.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Shell.d
@@ -665,7 +665,7 @@ override void createHandle (int index) {
         createHandle (index, false, true);
         OS.gtk_container_add (cast(GtkContainer*)vboxHandle, scrolledHandle);
         OS.gtk_box_set_child_packing (cast(GtkBox*)vboxHandle, scrolledHandle, true, true, 0, OS.GTK_PACK_END);
-        String dummy = "a";
+        String dummy = "";
         OS.gtk_window_set_title (cast(GtkWindow*)shellHandle, dummy.ptr );
         if ((style & (SWT.NO_TRIM | SWT.BORDER | SWT.SHELL_TRIM)) is 0) {
             OS.gtk_container_set_border_width (cast(GtkContainer*)shellHandle, 1);


### PR DESCRIPTION
https://github.com/d-widget-toolkit/dwt/issues/34#issuecomment-600725811
It seemed to be "a" long ago. For reference, current swt code:

     OS.gtk_window_set_title (shellHandle, new byte [1]);