### PR TITLE
Problems that occurs when creating a lot of widgets

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/glib_object.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/glib_object.d
@@ -3009,7 +3009,9 @@ extern (C) _GArray * function(_GArray *, void *, guint)g_array_prepend_vals;
 extern (C) _GArray * function(_GArray *, void *, guint)g_array_append_vals;
 extern (C) char * function(_GArray *, gint)g_array_free;
 extern (C) _GArray * function(gint, gint, guint, guint)g_array_sized_new;
-extern (C) _GArray * function(gint, gint, guint)g_array_new;"
+extern (C) _GArray * function(gint, gint, guint)g_array_new;
+extern (C) void function(_GClosure *)g_closure_sink;
+"
 ));
 
 Symbol[] symbols;
@@ -4424,7 +4426,8 @@ static this () {
         Symbol("g_array_append_vals",  cast(void**)& g_array_append_vals),
         Symbol("g_array_free",  cast(void**)& g_array_free),
         Symbol("g_array_sized_new",  cast(void**)& g_array_sized_new),
-        Symbol("g_array_new",  cast(void**)& g_array_new)
+        Symbol("g_array_new",  cast(void**)& g_array_new),
+        Symbol("g_closure_sink",  cast(void**)& g_closure_sink),
     ];
 }
 
@@ -5847,5 +5850,6 @@ extern (C) _GArray * g_array_append_vals(_GArray *, void *, guint);
 extern (C) char * g_array_free(_GArray *, gint);
 extern (C) _GArray * g_array_sized_new(gint, gint, guint, guint);
 extern (C) _GArray * g_array_new(gint, gint, guint);
+extern (C) void g_closure_sink(_GClosure *);
 } // version(DYNLINK)
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/glib_object.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/glib_object.d
@@ -3009,9 +3009,7 @@ extern (C) _GArray * function(_GArray *, void *, guint)g_array_prepend_vals;
 extern (C) _GArray * function(_GArray *, void *, guint)g_array_append_vals;
 extern (C) char * function(_GArray *, gint)g_array_free;
 extern (C) _GArray * function(gint, gint, guint, guint)g_array_sized_new;
-extern (C) _GArray * function(gint, gint, guint)g_array_new;
-extern (C) void function(_GClosure *)g_closure_sink;
-"
+extern (C) _GArray * function(gint, gint, guint)g_array_new;"
 ));
 
 Symbol[] symbols;
@@ -4426,8 +4424,7 @@ static this () {
         Symbol("g_array_append_vals",  cast(void**)& g_array_append_vals),
         Symbol("g_array_free",  cast(void**)& g_array_free),
         Symbol("g_array_sized_new",  cast(void**)& g_array_sized_new),
-        Symbol("g_array_new",  cast(void**)& g_array_new),
-        Symbol("g_closure_sink",  cast(void**)& g_closure_sink),
+        Symbol("g_array_new",  cast(void**)& g_array_new)
     ];
 }
 
@@ -5850,6 +5847,5 @@ extern (C) _GArray * g_array_append_vals(_GArray *, void *, guint);
 extern (C) char * g_array_free(_GArray *, gint);
 extern (C) _GArray * g_array_sized_new(gint, gint, guint, guint);
 extern (C) _GArray * g_array_new(gint, gint, guint);
-extern (C) void g_closure_sink(_GClosure *);
 } // version(DYNLINK)
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/gtk/OS.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/gtk/OS.d
@@ -674,6 +674,10 @@ private gint GTK_VERSION(){
     version( GTK_DYN_LINK ) return buildVERSION(*gtk_major_version, *gtk_minor_version, *gtk_micro_version);
     else                    return buildVERSION( gtk_major_version,  gtk_minor_version,  gtk_micro_version);
 }
+private gint GLIB_VERSION(){
+    version( DYNLINK ) return buildVERSION(*glib_major_version, *glib_minor_version, *glib_micro_version);
+    else               return buildVERSION( glib_major_version,  glib_minor_version,  glib_micro_version);
+}
 
 public class OS : Platform {
 
@@ -1158,6 +1162,9 @@ public class OS : Platform {
     }
 //     = buildVERSION(gtk_major_version(), gtk_minor_version(), gtk_micro_version());
 
+    public static gint GLIB_VERSION(){
+        return .GLIB_VERSION();
+    }
 
 public static gint buildVERSION(gint major, gint minor, gint micro) {
     return .buildVERSION( major, minor, micro );
@@ -1222,6 +1229,20 @@ public static const int PictOpOver = 3;
         version(GTK_DYN_LINK) return *.gtk_micro_version;
         else                  return .gtk_micro_version;
     }
+
+    public static gint glib_major_version(){
+        version(DYNLINK) return *.glib_minor_version;
+        else             return .glib_minor_version;
+    }
+    public static gint glib_minor_version(){
+        version(DYNLINK) return *.glib_minor_version;
+        else             return .glib_minor_version;
+    }
+    public static gint glib_micro_version(){
+        version(DYNLINK) return *.glib_micro_version;
+        else             return .glib_micro_version;
+    }
+
     mixin ForwardGtkOsCFunc!(localeconv_decimal_point);
     mixin ForwardGtkOsCFunc!(realpath);
 
@@ -1368,6 +1389,7 @@ public static const int PictOpOver = 3;
     mixin ForwardGtkOsCFunc!(.g_utf8_strlen);
     mixin ForwardGtkOsCFunc!(.g_utf8_to_utf16);
     mixin ForwardGtkOsCFunc!(.g_value_peek_pointer);
+    mixin ForwardGtkOsCFunc!(.g_closure_sink);
     mixin ForwardGtkOsCFunc!(.gdk_atom_intern);
     mixin ForwardGtkOsCFunc!(.gdk_atom_name);
     mixin ForwardGtkOsCFunc!(.gdk_beep);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Button.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Button.d
@@ -456,9 +456,9 @@ override int gtk_key_press_event (GtkWidget* widget, GdkEventKey* event) {
 
 override void hookEvents () {
     super.hookEvents();
-    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.closures [CLICKED], false);
+    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.getClosure (CLICKED), false);
     if (labelHandle !is null) {
-        OS.g_signal_connect_closure_by_id (cast(void*)labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
+        OS.g_signal_connect_closure_by_id (cast(void*)labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
     }
 }
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Combo.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Combo.d
@@ -683,15 +683,15 @@ override bool hasFocus () {
 override void hookEvents () {
     super.hookEvents ();
     if (OS.GTK_VERSION >= OS.buildVERSION(2, 4, 0)) {
-        OS.g_signal_connect_closure (handle, OS.changed.ptr, display.closures [CHANGED], true);
+        OS.g_signal_connect_closure (handle, OS.changed.ptr, display.getClosure (CHANGED), true);
     }
 
     if (entryHandle !is null) {
-        OS.g_signal_connect_closure (entryHandle, OS.changed.ptr, display.closures [CHANGED], true);
-        OS.g_signal_connect_closure (entryHandle, OS.insert_text.ptr, display.closures [INSERT_TEXT], false);
-        OS.g_signal_connect_closure (entryHandle, OS.delete_text.ptr, display.closures [DELETE_TEXT], false);
-        OS.g_signal_connect_closure (entryHandle, OS.activate.ptr, display.closures [ACTIVATE], false);
-        OS.g_signal_connect_closure (entryHandle, OS.populate_popup.ptr, display.closures [POPULATE_POPUP], false);
+        OS.g_signal_connect_closure (entryHandle, OS.changed.ptr, display.getClosure (CHANGED), true);
+        OS.g_signal_connect_closure (entryHandle, OS.insert_text.ptr, display.getClosure (INSERT_TEXT), false);
+        OS.g_signal_connect_closure (entryHandle, OS.delete_text.ptr, display.getClosure (DELETE_TEXT), false);
+        OS.g_signal_connect_closure (entryHandle, OS.activate.ptr, display.getClosure (ACTIVATE), false);
+        OS.g_signal_connect_closure (entryHandle, OS.populate_popup.ptr, display.getClosure (POPULATE_POPUP), false);
     }
     int eventMask = OS.GDK_POINTER_MOTION_MASK | OS.GDK_BUTTON_PRESS_MASK |
         OS.GDK_BUTTON_RELEASE_MASK;
@@ -701,9 +701,9 @@ override void hookEvents () {
         if (eventHandle !is null) {
             /* Connect the mouse signals */
             OS.gtk_widget_add_events (eventHandle, eventMask);
-            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT], false);
-            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.closures [BUTTON_RELEASE_EVENT], false);
-            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.closures [MOTION_NOTIFY_EVENT], false);
+            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT), false);
+            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.getClosure (BUTTON_RELEASE_EVENT), false);
+            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.getClosure (MOTION_NOTIFY_EVENT), false);
             /*
             * Feature in GTK.  Events such as mouse move are propagated up
             * the widget hierarchy and are seen by the parent.  This is the
@@ -711,19 +711,19 @@ override void hookEvents () {
             * hook a signal after and stop the propagation using a negative
             * event number to distinguish this case.
             */
-            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT_INVERSE], true);
-            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.closures [BUTTON_RELEASE_EVENT_INVERSE], true);
-            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.closures [MOTION_NOTIFY_EVENT_INVERSE], true);
+            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT_INVERSE), true);
+            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.getClosure (BUTTON_RELEASE_EVENT_INVERSE), true);
+            OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.getClosure (MOTION_NOTIFY_EVENT_INVERSE), true);
 
             /* Connect the event_after signal for both key and mouse */
             if (eventHandle !is focusHandle ()) {
-                OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [EVENT_AFTER], 0, display.closures [EVENT_AFTER], false);
+                OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [EVENT_AFTER], 0, display.getClosure (EVENT_AFTER), false);
             }
         }
     }
     auto imContext = imContext ();
     if (imContext !is null) {
-        OS.g_signal_connect_closure (imContext, OS.commit.ptr, display.closures [COMMIT], false);
+        OS.g_signal_connect_closure (imContext, OS.commit.ptr, display.getClosure (COMMIT), false);
         int id = OS.g_signal_lookup (OS.commit.ptr, OS.gtk_im_context_get_type ());
         int blockMask =  OS.G_SIGNAL_MATCH_DATA | OS.G_SIGNAL_MATCH_ID;
         OS.g_signal_handlers_block_matched (imContext, blockMask, id, 0, null, null, entryHandle);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Composite.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Composite.d
@@ -801,7 +801,7 @@ override void hookEvents () {
     if ((state & CANVAS) !is 0) {
         OS.gtk_widget_add_events (handle, OS.GDK_POINTER_MOTION_HINT_MASK);
         if (scrolledHandle !is null) {
-            OS.g_signal_connect_closure (scrolledHandle, OS.scroll_child.ptr, display.closures [SCROLL_CHILD], false);
+            OS.g_signal_connect_closure (scrolledHandle, OS.scroll_child.ptr, display.getClosure (SCROLL_CHILD), false);
         }
     }
 }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Control.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Control.d
@@ -235,29 +235,29 @@ override void hookEvents () {
     auto focusHandle_ = focusHandle ();
     int focusMask = OS.GDK_KEY_PRESS_MASK | OS.GDK_KEY_RELEASE_MASK | OS.GDK_FOCUS_CHANGE_MASK;
     OS.gtk_widget_add_events (focusHandle_, focusMask);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [POPUP_MENU], 0, display.closures [POPUP_MENU], false);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [SHOW_HELP], 0, display.closures [SHOW_HELP], false);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [KEY_PRESS_EVENT], 0, display.closures [KEY_PRESS_EVENT], false);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [KEY_RELEASE_EVENT], 0, display.closures [KEY_RELEASE_EVENT], false);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [FOCUS], 0, display.closures [FOCUS], false);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [FOCUS_IN_EVENT], 0, display.closures [FOCUS_IN_EVENT], false);
-    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [FOCUS_OUT_EVENT], 0, display.closures [FOCUS_OUT_EVENT], false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [POPUP_MENU], 0, display.getClosure (POPUP_MENU), false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [SHOW_HELP], 0, display.getClosure (SHOW_HELP), false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [KEY_PRESS_EVENT], 0, display.getClosure (KEY_PRESS_EVENT), false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [KEY_RELEASE_EVENT], 0, display.getClosure (KEY_RELEASE_EVENT), false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [FOCUS], 0, display.getClosure (FOCUS), false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [FOCUS_IN_EVENT], 0, display.getClosure (FOCUS_IN_EVENT), false);
+    OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [FOCUS_OUT_EVENT], 0, display.getClosure (FOCUS_OUT_EVENT), false);
 
     /* Connect the mouse signals */
     auto eventHandle = eventHandle ();
     int eventMask = OS.GDK_POINTER_MOTION_MASK | OS.GDK_BUTTON_PRESS_MASK | OS.GDK_BUTTON_RELEASE_MASK;
     OS.gtk_widget_add_events (eventHandle, eventMask);
-    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT], false);
-    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.closures [BUTTON_RELEASE_EVENT], false);
-    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.closures [MOTION_NOTIFY_EVENT], false);
-    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [SCROLL_EVENT], 0, display.closures [SCROLL_EVENT], false);
+    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT), false);
+    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.getClosure (BUTTON_RELEASE_EVENT), false);
+    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.getClosure (MOTION_NOTIFY_EVENT), false);
+    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [SCROLL_EVENT], 0, display.getClosure (SCROLL_EVENT), false);
 
     /* Connect enter/exit signals */
     auto enterExitHandle = enterExitHandle ();
     int enterExitMask = OS.GDK_ENTER_NOTIFY_MASK | OS.GDK_LEAVE_NOTIFY_MASK;
     OS.gtk_widget_add_events (enterExitHandle, enterExitMask);
-    OS.g_signal_connect_closure_by_id (enterExitHandle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.closures [ENTER_NOTIFY_EVENT], false);
-    OS.g_signal_connect_closure_by_id (enterExitHandle, display.signalIds [LEAVE_NOTIFY_EVENT], 0, display.closures [LEAVE_NOTIFY_EVENT], false);
+    OS.g_signal_connect_closure_by_id (enterExitHandle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.getClosure (ENTER_NOTIFY_EVENT), false);
+    OS.g_signal_connect_closure_by_id (enterExitHandle, display.signalIds [LEAVE_NOTIFY_EVENT], 0, display.getClosure (LEAVE_NOTIFY_EVENT), false);
 
     /*
     * Feature in GTK.  Events such as mouse move are propagate up
@@ -270,37 +270,37 @@ override void hookEvents () {
     * lightweight widgets.
     */
     auto blockHandle = fixedHandle !is null ? fixedHandle : eventHandle;
-    OS.g_signal_connect_closure_by_id (blockHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT_INVERSE], true);
-    OS.g_signal_connect_closure_by_id (blockHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.closures [BUTTON_RELEASE_EVENT_INVERSE], true);
-    OS.g_signal_connect_closure_by_id (blockHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.closures [MOTION_NOTIFY_EVENT_INVERSE], true);
+    OS.g_signal_connect_closure_by_id (blockHandle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT_INVERSE), true);
+    OS.g_signal_connect_closure_by_id (blockHandle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.getClosure (BUTTON_RELEASE_EVENT_INVERSE), true);
+    OS.g_signal_connect_closure_by_id (blockHandle, display.signalIds [MOTION_NOTIFY_EVENT], 0, display.getClosure (MOTION_NOTIFY_EVENT_INVERSE), true);
 
     /* Connect the event_after signal for both key and mouse */
-    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [EVENT_AFTER], 0, display.closures [EVENT_AFTER], false);
+    OS.g_signal_connect_closure_by_id (eventHandle, display.signalIds [EVENT_AFTER], 0, display.getClosure (EVENT_AFTER), false);
     if (focusHandle_ !is eventHandle) {
-        OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [EVENT_AFTER], 0, display.closures [EVENT_AFTER], false);
+        OS.g_signal_connect_closure_by_id (focusHandle_, display.signalIds [EVENT_AFTER], 0, display.getClosure (EVENT_AFTER), false);
     }
 
     /* Connect the paint signal */
     auto paintHandle = paintHandle ();
     int paintMask = OS.GDK_EXPOSURE_MASK | OS.GDK_VISIBILITY_NOTIFY_MASK;
     OS.gtk_widget_add_events (paintHandle, paintMask);
-    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [EXPOSE_EVENT], 0, display.closures [EXPOSE_EVENT_INVERSE], false);
-    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [VISIBILITY_NOTIFY_EVENT], 0, display.closures [VISIBILITY_NOTIFY_EVENT], false);
-    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [EXPOSE_EVENT], 0, display.closures [EXPOSE_EVENT], true);
+    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [EXPOSE_EVENT], 0, display.getClosure (EXPOSE_EVENT_INVERSE), false);
+    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [VISIBILITY_NOTIFY_EVENT], 0, display.getClosure (VISIBILITY_NOTIFY_EVENT), false);
+    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [EXPOSE_EVENT], 0, display.getClosure (EXPOSE_EVENT), true);
 
     /* Connect the Input Method signals */
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [REALIZE], 0, display.closures [REALIZE], true);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [UNREALIZE], 0, display.closures [UNREALIZE], false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [REALIZE], 0, display.getClosure (REALIZE), true);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [UNREALIZE], 0, display.getClosure (UNREALIZE), false);
     auto imHandle = imHandle ();
     if (imHandle !is null) {
-        OS.g_signal_connect_closure (imHandle, OS.commit.ptr, display.closures [COMMIT], false);
-        OS.g_signal_connect_closure (imHandle, OS.preedit_changed.ptr, display.closures [PREEDIT_CHANGED], false);
+        OS.g_signal_connect_closure (imHandle, OS.commit.ptr, display.getClosure (COMMIT), false);
+        OS.g_signal_connect_closure (imHandle, OS.preedit_changed.ptr, display.getClosure (PREEDIT_CHANGED), false);
     }
 
-    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [STYLE_SET], 0, display.closures [STYLE_SET], false);
+    OS.g_signal_connect_closure_by_id (paintHandle, display.signalIds [STYLE_SET], 0, display.getClosure (STYLE_SET), false);
 
     auto topHandle_ = topHandle ();
-    OS.g_signal_connect_closure_by_id (topHandle_, display.signalIds [MAP], 0, display.closures [MAP], true);
+    OS.g_signal_connect_closure_by_id (topHandle_, display.signalIds [MAP], 0, display.getClosure (MAP), true);
 }
 
 override int hoverProc (GtkWidget* widget) {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/DateTime.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/DateTime.d
@@ -793,8 +793,8 @@ override
 void hookEvents () {
     super.hookEvents();
     if ((style & SWT.CALENDAR) !is 0) {
-        OS.g_signal_connect_closure (handle, OS.day_selected.ptr, display.closures [DAY_SELECTED], false);
-        OS.g_signal_connect_closure (handle, OS.month_changed.ptr, display.closures [MONTH_CHANGED], false);
+        OS.g_signal_connect_closure (handle, OS.day_selected.ptr, display.getClosure (DAY_SELECTED), false);
+        OS.g_signal_connect_closure (handle, OS.month_changed.ptr, display.getClosure (MONTH_CHANGED), false);
     }
 }
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
@@ -659,7 +659,7 @@ void addPopup (Menu menu) {
 void addWidget (GtkWidget* handle, Widget widget) {
     if (handle is null) return;
     if (freeSlot is -1) {
-        ptrdiff_t len = freeSlot = indexTable.length + GROW_SIZE;
+        ptrdiff_t len = (freeSlot = indexTable.length) + GROW_SIZE;
         ptrdiff_t[] newIndexTable = new ptrdiff_t[len];
         Widget[] newWidgetTable = new Widget [len];
         System.arraycopy (indexTable, 0, newIndexTable, 0, freeSlot);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
@@ -29,6 +29,7 @@ import org.eclipse.swt.internal.Compatibility;
 import org.eclipse.swt.internal.Converter;
 import org.eclipse.swt.internal.Lock;
 import org.eclipse.swt.internal.LONG;
+import org.eclipse.swt.internal.c.glib_object;
 import org.eclipse.swt.internal.gtk.OS;
 import org.eclipse.swt.widgets.Caret;
 import org.eclipse.swt.widgets.Control;
@@ -150,6 +151,8 @@ public class Display : Device {
     static const String DISPATCH_EVENT_KEY = "org.eclipse.swt.internal.gtk.dispatchEvent";
     static const String ADD_WIDGET_KEY = "org.eclipse.swt.internal.addWidget";
     GClosure*[] closures;
+    GCallback[] closuresProc;
+    int [] closuresCount;
     int [] signalIds;
 
     /* Widget Table */
@@ -1447,6 +1450,18 @@ int getCaretBlinkTime () {
     return buffer / 2;
 }
 
+GClosure* getClosure (int id) {
+    if (OS.GLIB_VERSION >= OS.buildVERSION(2, 36, 0) && ++closuresCount [id] >= 255) {
+        if (closures [id] !is null) OS.g_closure_unref (closures [id]);
+        auto res = windowProcCallbackDatas [id];
+        closures [id] = OS.g_cclosure_new (closuresProc [id], res, null);
+        OS.g_closure_ref (closures [id]);
+        OS.g_closure_sink (closures [id]);
+        closuresCount [id] = 0;
+    }
+    return closures [id];
+}
+
 /**
  * Returns the control which the on-screen pointer is currently
  * over top of, or null if it is not currently over one of the
@@ -2393,6 +2408,8 @@ protected override void init_ () {
 
 void initializeCallbacks () {
     closures = new GClosure* [Widget.LAST_SIGNAL];
+    closuresCount = new int[Widget.LAST_SIGNAL];
+    closuresProc = new GCallback [Widget.LAST_SIGNAL];
     signalIds = new int [Widget.LAST_SIGNAL];
 
     /* Cache signals for GtkWidget */
@@ -2429,88 +2446,95 @@ void initializeCallbacks () {
     signalIds [Widget.VISIBILITY_NOTIFY_EVENT] = OS.g_signal_lookup (OS.visibility_notify_event.ptr, OS.GTK_TYPE_WIDGET ());
     signalIds [Widget.WINDOW_STATE_EVENT] = OS.g_signal_lookup (OS.window_state_event.ptr, OS.GTK_TYPE_WIDGET ());
 
-    GClosure* do_cclosure_new( GCallback cb, int value, ptrdiff_t notify ){
+    GCallback do_cclosure_new( GCallback cb, int value, ptrdiff_t notify ){
         CallbackData* res= new CallbackData;
         res.display = this;
         res.data = cast(void*)value;
         windowProcCallbackDatas[ value ] = res;
-        return OS.g_cclosure_new( cb, cast(void*)res, cast(GClosureNotify)notify );
+        return cb;
     }
 
     GCallback windowProc2 = cast(GCallback)&windowProcFunc2;
-    closures [Widget.ACTIVATE] = do_cclosure_new (windowProc2, Widget.ACTIVATE, 0);
-    closures [Widget.ACTIVATE_INVERSE] = do_cclosure_new (windowProc2, Widget.ACTIVATE_INVERSE, 0);
-    closures [Widget.CHANGED] = do_cclosure_new (windowProc2, Widget.CHANGED, 0);
-    closures [Widget.CLICKED] = do_cclosure_new (windowProc2, Widget.CLICKED, 0);
-    closures [Widget.DAY_SELECTED] = do_cclosure_new (windowProc2, Widget.DAY_SELECTED, 0);
-    closures [Widget.HIDE] = do_cclosure_new (windowProc2, Widget.HIDE, 0);
-    closures [Widget.GRAB_FOCUS] = do_cclosure_new (windowProc2, Widget.GRAB_FOCUS, 0);
-    closures [Widget.MAP] = do_cclosure_new (windowProc2, Widget.MAP, 0);
-    closures [Widget.MONTH_CHANGED] = do_cclosure_new (windowProc2, Widget.MONTH_CHANGED, 0);
-    closures [Widget.OUTPUT] = do_cclosure_new (windowProc2, Widget.OUTPUT, 0);
-    closures [Widget.POPUP_MENU] = do_cclosure_new (windowProc2, Widget.POPUP_MENU, 0);
-    closures [Widget.PREEDIT_CHANGED] = do_cclosure_new (windowProc2, Widget.PREEDIT_CHANGED, 0);
-    closures [Widget.REALIZE] = do_cclosure_new (windowProc2, Widget.REALIZE, 0);
-    closures [Widget.SELECT] = do_cclosure_new (windowProc2, Widget.SELECT, 0);
-    closures [Widget.SHOW] = do_cclosure_new (windowProc2, Widget.SHOW, 0);
-    closures [Widget.VALUE_CHANGED] = do_cclosure_new (windowProc2, Widget.VALUE_CHANGED, 0);
-    closures [Widget.UNMAP] = do_cclosure_new (windowProc2, Widget.UNMAP, 0);
-    closures [Widget.UNREALIZE] = do_cclosure_new (windowProc2, Widget.UNREALIZE, 0);
+    closuresProc [Widget.ACTIVATE] = do_cclosure_new (windowProc2, Widget.ACTIVATE, 0);
+    closuresProc [Widget.ACTIVATE_INVERSE] = do_cclosure_new (windowProc2, Widget.ACTIVATE_INVERSE, 0);
+    closuresProc [Widget.CHANGED] = do_cclosure_new (windowProc2, Widget.CHANGED, 0);
+    closuresProc [Widget.CLICKED] = do_cclosure_new (windowProc2, Widget.CLICKED, 0);
+    closuresProc [Widget.DAY_SELECTED] = do_cclosure_new (windowProc2, Widget.DAY_SELECTED, 0);
+    closuresProc [Widget.HIDE] = do_cclosure_new (windowProc2, Widget.HIDE, 0);
+    closuresProc [Widget.GRAB_FOCUS] = do_cclosure_new (windowProc2, Widget.GRAB_FOCUS, 0);
+    closuresProc [Widget.MAP] = do_cclosure_new (windowProc2, Widget.MAP, 0);
+    closuresProc [Widget.MONTH_CHANGED] = do_cclosure_new (windowProc2, Widget.MONTH_CHANGED, 0);
+    closuresProc [Widget.OUTPUT] = do_cclosure_new (windowProc2, Widget.OUTPUT, 0);
+    closuresProc [Widget.POPUP_MENU] = do_cclosure_new (windowProc2, Widget.POPUP_MENU, 0);
+    closuresProc [Widget.PREEDIT_CHANGED] = do_cclosure_new (windowProc2, Widget.PREEDIT_CHANGED, 0);
+    closuresProc [Widget.REALIZE] = do_cclosure_new (windowProc2, Widget.REALIZE, 0);
+    closuresProc [Widget.SELECT] = do_cclosure_new (windowProc2, Widget.SELECT, 0);
+    closuresProc [Widget.SHOW] = do_cclosure_new (windowProc2, Widget.SHOW, 0);
+    closuresProc [Widget.VALUE_CHANGED] = do_cclosure_new (windowProc2, Widget.VALUE_CHANGED, 0);
+    closuresProc [Widget.UNMAP] = do_cclosure_new (windowProc2, Widget.UNMAP, 0);
+    closuresProc [Widget.UNREALIZE] = do_cclosure_new (windowProc2, Widget.UNREALIZE, 0);
 
     GCallback windowProc3 = cast(GCallback)&windowProcFunc3;
-    closures [Widget.BUTTON_PRESS_EVENT] = do_cclosure_new (windowProc3, Widget.BUTTON_PRESS_EVENT, 0);
-    closures [Widget.BUTTON_PRESS_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.BUTTON_PRESS_EVENT_INVERSE, 0);
-    closures [Widget.BUTTON_RELEASE_EVENT] = do_cclosure_new (windowProc3, Widget.BUTTON_RELEASE_EVENT, 0);
-    closures [Widget.BUTTON_RELEASE_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.BUTTON_RELEASE_EVENT_INVERSE, 0);
-    closures [Widget.COMMIT] = do_cclosure_new (windowProc3, Widget.COMMIT, 0);
-    closures [Widget.CONFIGURE_EVENT] = do_cclosure_new (windowProc3, Widget.CONFIGURE_EVENT, 0);
-    closures [Widget.DELETE_EVENT] = do_cclosure_new (windowProc3, Widget.DELETE_EVENT, 0);
-    closures [Widget.ENTER_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.ENTER_NOTIFY_EVENT, 0);
-    closures [Widget.EVENT] = do_cclosure_new (windowProc3, Widget.EVENT, 0);
-    closures [Widget.EVENT_AFTER] = do_cclosure_new (windowProc3, Widget.EVENT_AFTER, 0);
-    closures [Widget.EXPOSE_EVENT] = do_cclosure_new (windowProc3, Widget.EXPOSE_EVENT, 0);
-    closures [Widget.EXPOSE_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.EXPOSE_EVENT_INVERSE, 0);
-    closures [Widget.FOCUS] = do_cclosure_new (windowProc3, Widget.FOCUS, 0);
-    closures [Widget.FOCUS_IN_EVENT] = do_cclosure_new (windowProc3, Widget.FOCUS_IN_EVENT, 0);
-    closures [Widget.FOCUS_OUT_EVENT] = do_cclosure_new (windowProc3, Widget.FOCUS_OUT_EVENT, 0);
-    closures [Widget.KEY_PRESS_EVENT] = do_cclosure_new (windowProc3, Widget.KEY_PRESS_EVENT, 0);
-    closures [Widget.KEY_RELEASE_EVENT] = do_cclosure_new (windowProc3, Widget.KEY_RELEASE_EVENT, 0);
-    closures [Widget.INPUT] = do_cclosure_new (windowProc3, Widget.INPUT, 0);
-    closures [Widget.LEAVE_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.LEAVE_NOTIFY_EVENT, 0);
-    closures [Widget.MAP_EVENT] = do_cclosure_new (windowProc3, Widget.MAP_EVENT, 0);
-    closures [Widget.MNEMONIC_ACTIVATE] = do_cclosure_new (windowProc3, Widget.MNEMONIC_ACTIVATE, 0);
-    closures [Widget.MOTION_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.MOTION_NOTIFY_EVENT, 0);
-    closures [Widget.MOTION_NOTIFY_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.MOTION_NOTIFY_EVENT_INVERSE, 0);
-    closures [Widget.MOVE_FOCUS] = do_cclosure_new (windowProc3, Widget.MOVE_FOCUS, 0);
-    closures [Widget.POPULATE_POPUP] = do_cclosure_new (windowProc3, Widget.POPULATE_POPUP, 0);
-    closures [Widget.SCROLL_EVENT] = do_cclosure_new (windowProc3, Widget.SCROLL_EVENT, 0);
-    closures [Widget.SHOW_HELP] = do_cclosure_new (windowProc3, Widget.SHOW_HELP, 0);
-    closures [Widget.SIZE_ALLOCATE] = do_cclosure_new (windowProc3, Widget.SIZE_ALLOCATE, 0);
-    closures [Widget.STYLE_SET] = do_cclosure_new (windowProc3, Widget.STYLE_SET, 0);
-    closures [Widget.TOGGLED] = do_cclosure_new (windowProc3, Widget.TOGGLED, 0);
-    closures [Widget.UNMAP_EVENT] = do_cclosure_new (windowProc3, Widget.UNMAP_EVENT, 0);
-    closures [Widget.VISIBILITY_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.VISIBILITY_NOTIFY_EVENT, 0);
-    closures [Widget.WINDOW_STATE_EVENT] = do_cclosure_new (windowProc3, Widget.WINDOW_STATE_EVENT, 0);
+    closuresProc [Widget.BUTTON_PRESS_EVENT] = do_cclosure_new (windowProc3, Widget.BUTTON_PRESS_EVENT, 0);
+    closuresProc [Widget.BUTTON_PRESS_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.BUTTON_PRESS_EVENT_INVERSE, 0);
+    closuresProc [Widget.BUTTON_RELEASE_EVENT] = do_cclosure_new (windowProc3, Widget.BUTTON_RELEASE_EVENT, 0);
+    closuresProc [Widget.BUTTON_RELEASE_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.BUTTON_RELEASE_EVENT_INVERSE, 0);
+    closuresProc [Widget.COMMIT] = do_cclosure_new (windowProc3, Widget.COMMIT, 0);
+    closuresProc [Widget.CONFIGURE_EVENT] = do_cclosure_new (windowProc3, Widget.CONFIGURE_EVENT, 0);
+    closuresProc [Widget.DELETE_EVENT] = do_cclosure_new (windowProc3, Widget.DELETE_EVENT, 0);
+    closuresProc [Widget.ENTER_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.ENTER_NOTIFY_EVENT, 0);
+    closuresProc [Widget.EVENT] = do_cclosure_new (windowProc3, Widget.EVENT, 0);
+    closuresProc [Widget.EVENT_AFTER] = do_cclosure_new (windowProc3, Widget.EVENT_AFTER, 0);
+    closuresProc [Widget.EXPOSE_EVENT] = do_cclosure_new (windowProc3, Widget.EXPOSE_EVENT, 0);
+    closuresProc [Widget.EXPOSE_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.EXPOSE_EVENT_INVERSE, 0);
+    closuresProc [Widget.FOCUS] = do_cclosure_new (windowProc3, Widget.FOCUS, 0);
+    closuresProc [Widget.FOCUS_IN_EVENT] = do_cclosure_new (windowProc3, Widget.FOCUS_IN_EVENT, 0);
+    closuresProc [Widget.FOCUS_OUT_EVENT] = do_cclosure_new (windowProc3, Widget.FOCUS_OUT_EVENT, 0);
+    closuresProc [Widget.KEY_PRESS_EVENT] = do_cclosure_new (windowProc3, Widget.KEY_PRESS_EVENT, 0);
+    closuresProc [Widget.KEY_RELEASE_EVENT] = do_cclosure_new (windowProc3, Widget.KEY_RELEASE_EVENT, 0);
+    closuresProc [Widget.INPUT] = do_cclosure_new (windowProc3, Widget.INPUT, 0);
+    closuresProc [Widget.LEAVE_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.LEAVE_NOTIFY_EVENT, 0);
+    closuresProc [Widget.MAP_EVENT] = do_cclosure_new (windowProc3, Widget.MAP_EVENT, 0);
+    closuresProc [Widget.MNEMONIC_ACTIVATE] = do_cclosure_new (windowProc3, Widget.MNEMONIC_ACTIVATE, 0);
+    closuresProc [Widget.MOTION_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.MOTION_NOTIFY_EVENT, 0);
+    closuresProc [Widget.MOTION_NOTIFY_EVENT_INVERSE] = do_cclosure_new (windowProc3, Widget.MOTION_NOTIFY_EVENT_INVERSE, 0);
+    closuresProc [Widget.MOVE_FOCUS] = do_cclosure_new (windowProc3, Widget.MOVE_FOCUS, 0);
+    closuresProc [Widget.POPULATE_POPUP] = do_cclosure_new (windowProc3, Widget.POPULATE_POPUP, 0);
+    closuresProc [Widget.SCROLL_EVENT] = do_cclosure_new (windowProc3, Widget.SCROLL_EVENT, 0);
+    closuresProc [Widget.SHOW_HELP] = do_cclosure_new (windowProc3, Widget.SHOW_HELP, 0);
+    closuresProc [Widget.SIZE_ALLOCATE] = do_cclosure_new (windowProc3, Widget.SIZE_ALLOCATE, 0);
+    closuresProc [Widget.STYLE_SET] = do_cclosure_new (windowProc3, Widget.STYLE_SET, 0);
+    closuresProc [Widget.TOGGLED] = do_cclosure_new (windowProc3, Widget.TOGGLED, 0);
+    closuresProc [Widget.UNMAP_EVENT] = do_cclosure_new (windowProc3, Widget.UNMAP_EVENT, 0);
+    closuresProc [Widget.VISIBILITY_NOTIFY_EVENT] = do_cclosure_new (windowProc3, Widget.VISIBILITY_NOTIFY_EVENT, 0);
+    closuresProc [Widget.WINDOW_STATE_EVENT] = do_cclosure_new (windowProc3, Widget.WINDOW_STATE_EVENT, 0);
 
     GCallback windowProc4 = cast(GCallback)&windowProcFunc4;
-    closures [Widget.DELETE_RANGE] = do_cclosure_new (windowProc4, Widget.DELETE_RANGE, 0);
-    closures [Widget.DELETE_TEXT] = do_cclosure_new (windowProc4, Widget.DELETE_TEXT, 0);
-    closures [Widget.ROW_ACTIVATED] = do_cclosure_new (windowProc4, Widget.ROW_ACTIVATED, 0);
-    closures [Widget.SCROLL_CHILD] = do_cclosure_new (windowProc4, Widget.SCROLL_CHILD, 0);
-    closures [Widget.SWITCH_PAGE] = do_cclosure_new (windowProc4, Widget.SWITCH_PAGE, 0);
-    closures [Widget.TEST_COLLAPSE_ROW] = do_cclosure_new (windowProc4, Widget.TEST_COLLAPSE_ROW, 0);
-    closures [Widget.TEST_EXPAND_ROW] = do_cclosure_new (windowProc4, Widget.TEST_EXPAND_ROW, 0);
+    closuresProc [Widget.DELETE_RANGE] = do_cclosure_new (windowProc4, Widget.DELETE_RANGE, 0);
+    closuresProc [Widget.DELETE_TEXT] = do_cclosure_new (windowProc4, Widget.DELETE_TEXT, 0);
+    closuresProc [Widget.ROW_ACTIVATED] = do_cclosure_new (windowProc4, Widget.ROW_ACTIVATED, 0);
+    closuresProc [Widget.SCROLL_CHILD] = do_cclosure_new (windowProc4, Widget.SCROLL_CHILD, 0);
+    closuresProc [Widget.SWITCH_PAGE] = do_cclosure_new (windowProc4, Widget.SWITCH_PAGE, 0);
+    closuresProc [Widget.TEST_COLLAPSE_ROW] = do_cclosure_new (windowProc4, Widget.TEST_COLLAPSE_ROW, 0);
+    closuresProc [Widget.TEST_EXPAND_ROW] = do_cclosure_new (windowProc4, Widget.TEST_EXPAND_ROW, 0);
 
     GCallback windowProc5 = cast(GCallback)&windowProcFunc5;
-    closures [Widget.EXPAND_COLLAPSE_CURSOR_ROW] = do_cclosure_new (windowProc5, Widget.EXPAND_COLLAPSE_CURSOR_ROW, 0);
-    closures [Widget.INSERT_TEXT] = do_cclosure_new (windowProc5, Widget.INSERT_TEXT, 0);
-    closures [Widget.TEXT_BUFFER_INSERT_TEXT] = do_cclosure_new (windowProc5, Widget.TEXT_BUFFER_INSERT_TEXT, 0);
+    closuresProc [Widget.EXPAND_COLLAPSE_CURSOR_ROW] = do_cclosure_new (windowProc5, Widget.EXPAND_COLLAPSE_CURSOR_ROW, 0);
+    closuresProc [Widget.INSERT_TEXT] = do_cclosure_new (windowProc5, Widget.INSERT_TEXT, 0);
+    closuresProc [Widget.TEXT_BUFFER_INSERT_TEXT] = do_cclosure_new (windowProc5, Widget.TEXT_BUFFER_INSERT_TEXT, 0);
 
     GCallback windowChangeValueProc = cast(GCallback)&windowProcChangeValueFunc;
-    closures [Widget.CHANGE_VALUE] = do_cclosure_new (windowChangeValueProc, Widget.CHANGE_VALUE, 0);
+    closuresProc [Widget.CHANGE_VALUE] = do_cclosure_new (windowChangeValueProc, Widget.CHANGE_VALUE, 0);
 
     for (int i = 0; i < Widget.LAST_SIGNAL; i++) {
-        if (closures [i] !is null) OS.g_closure_ref (closures [i]);
+        if (closuresProc[i] !is null) {
+            auto res = windowProcCallbackDatas [i];
+            closures [i] = OS.g_cclosure_new(closuresProc [i], res, null);
+        }
+        if (closures [i] !is null) {
+            OS.g_closure_ref (closures [i]);
+            OS.g_closure_sink (closures [i]);
+        }
     }
     shellMapProcCallbackData.display = this;
     shellMapProcCallbackData.data = null;

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ExpandItem.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ExpandItem.d
@@ -371,12 +371,12 @@ bool hasFocus () {
 override void hookEvents () {
     super.hookEvents ();
     if (OS.GTK_VERSION >= OS.buildVERSION (2, 4, 0)) {
-        OS.g_signal_connect_closure (handle, OS.activate.ptr, display.closures [ACTIVATE], false);
-        OS.g_signal_connect_closure (handle, OS.activate.ptr, display.closures [ACTIVATE_INVERSE], true);
-        OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT], false);
-        OS.g_signal_connect_closure_by_id (handle, display.signalIds [FOCUS_OUT_EVENT], 0, display.closures [FOCUS_OUT_EVENT], false);
-        OS.g_signal_connect_closure (clientHandle, OS.size_allocate.ptr, display.closures [SIZE_ALLOCATE], true);
-        OS.g_signal_connect_closure_by_id (handle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.closures [ENTER_NOTIFY_EVENT], false);
+        OS.g_signal_connect_closure (handle, OS.activate.ptr, display.getClosure (ACTIVATE), false);
+        OS.g_signal_connect_closure (handle, OS.activate.ptr, display.getClosure (ACTIVATE_INVERSE), true);
+        OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT), false);
+        OS.g_signal_connect_closure_by_id (handle, display.signalIds [FOCUS_OUT_EVENT], 0, display.getClosure (FOCUS_OUT_EVENT), false);
+        OS.g_signal_connect_closure (clientHandle, OS.size_allocate.ptr, display.getClosure (SIZE_ALLOCATE), true);
+        OS.g_signal_connect_closure_by_id (handle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.getClosure (ENTER_NOTIFY_EVENT), false);
     }
 }
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Group.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Group.d
@@ -198,7 +198,7 @@ public String getText () {
 override void hookEvents () {
     super.hookEvents();
     if (labelHandle !is null) {
-        OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
+        OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
     }
 }
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Label.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Label.d
@@ -321,7 +321,7 @@ public String getText () {
 override void hookEvents () {
     super.hookEvents();
     if (labelHandle !is null) {
-        OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
+        OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
     }
 }
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/List.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/List.d
@@ -813,8 +813,8 @@ override void gtk_row_activated (GtkTreeView* tree, GtkTreePath* path, GtkTreeVi
 override void hookEvents () {
     super.hookEvents();
     auto selection = OS.gtk_tree_view_get_selection(cast(GtkTreeView*)handle);
-    OS.g_signal_connect_closure (selection, OS.changed.ptr, display.closures [CHANGED], false);
-    OS.g_signal_connect_closure (handle, OS.row_activated.ptr, display.closures [ROW_ACTIVATED], false);
+    OS.g_signal_connect_closure (selection, OS.changed.ptr, display.getClosure (CHANGED), false);
+    OS.g_signal_connect_closure (handle, OS.row_activated.ptr, display.getClosure (ROW_ACTIVATED), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Menu.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Menu.d
@@ -647,9 +647,9 @@ override int gtk_show_help (GtkWidget* widget, ptrdiff_t helpType) {
 
 override void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [SHOW], 0, display.closures [SHOW], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [HIDE], 0, display.closures [HIDE], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [SHOW_HELP], 0, display.closures [SHOW_HELP], false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [SHOW], 0, display.getClosure (SHOW), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [HIDE], 0, display.getClosure (HIDE), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [SHOW_HELP], 0, display.getClosure (SHOW_HELP), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/MenuItem.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/MenuItem.d
@@ -475,9 +475,9 @@ override int gtk_show_help (GtkWidget* widget, ptrdiff_t helpType) {
 
 override void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure (handle, OS.activate.ptr, display.closures [ACTIVATE], false);
-    OS.g_signal_connect_closure (handle, OS.select.ptr, display.closures [SELECT], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [SHOW_HELP], 0, display.closures [SHOW_HELP], false);
+    OS.g_signal_connect_closure (handle, OS.activate.ptr, display.getClosure (ACTIVATE), false);
+    OS.g_signal_connect_closure (handle, OS.select.ptr, display.getClosure (SELECT), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [SHOW_HELP], 0, display.getClosure (SHOW_HELP), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Scale.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Scale.d
@@ -151,7 +151,7 @@ override void createHandle (int index) {
 
 override void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure (handle, OS.value_changed.ptr, display.closures [VALUE_CHANGED], false);
+    OS.g_signal_connect_closure (handle, OS.value_changed.ptr, display.getClosure (VALUE_CHANGED), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ScrollBar.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ScrollBar.d
@@ -419,11 +419,11 @@ override int gtk_event_after (GtkWidget* widget, GdkEvent* gdkEvent) {
 override void hookEvents () {
     super.hookEvents ();
     if (OS.GTK_VERSION >= OS.buildVERSION (2, 6, 0)) {
-        OS.g_signal_connect_closure (handle, OS.change_value.ptr, display.closures [CHANGE_VALUE], false);
+        OS.g_signal_connect_closure (handle, OS.change_value.ptr, display.getClosure (CHANGE_VALUE), false);
     }
-    OS.g_signal_connect_closure (adjustmentHandle, OS.value_changed.ptr, display.closures [VALUE_CHANGED], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [EVENT_AFTER], 0, display.closures [EVENT_AFTER], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT], false);
+    OS.g_signal_connect_closure (adjustmentHandle, OS.value_changed.ptr, display.getClosure (VALUE_CHANGED), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [EVENT_AFTER], 0, display.getClosure (EVENT_AFTER), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Shell.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Shell.d
@@ -754,14 +754,14 @@ override bool hasBorder () {
 
 override void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [KEY_PRESS_EVENT], 0, display.closures [KEY_PRESS_EVENT], false);
-    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [WINDOW_STATE_EVENT], 0, display.closures [WINDOW_STATE_EVENT], false);
-    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [SIZE_ALLOCATE], 0, display.closures [SIZE_ALLOCATE], false);
-    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [CONFIGURE_EVENT], 0, display.closures [CONFIGURE_EVENT], false);
-    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [DELETE_EVENT], 0, display.closures [DELETE_EVENT], false);
+    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [KEY_PRESS_EVENT], 0, display.getClosure (KEY_PRESS_EVENT), false);
+    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [WINDOW_STATE_EVENT], 0, display.getClosure (WINDOW_STATE_EVENT), false);
+    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [SIZE_ALLOCATE], 0, display.getClosure (SIZE_ALLOCATE), false);
+    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [CONFIGURE_EVENT], 0, display.getClosure (CONFIGURE_EVENT), false);
+    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [DELETE_EVENT], 0, display.getClosure (DELETE_EVENT), false);
     OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [MAP_EVENT], 0, display.shellMapProcClosure, false);
-    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.closures [ENTER_NOTIFY_EVENT], false);
-    OS.g_signal_connect_closure (shellHandle, OS.move_focus.ptr, display.closures [MOVE_FOCUS], false);
+    OS.g_signal_connect_closure_by_id (shellHandle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.getClosure (ENTER_NOTIFY_EVENT), false);
+    OS.g_signal_connect_closure (shellHandle, OS.move_focus.ptr, display.getClosure (MOVE_FOCUS), false);
     auto window = OS.GTK_WIDGET_WINDOW (shellHandle);
     display.doWindowAddFilter( &filterProcCallbackData, window, shellHandle );
     //OS.gdk_window_add_filter  (window, display.filterProc, shellHandle);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Slider.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Slider.d
@@ -249,9 +249,9 @@ override int gtk_event_after (GtkWidget* widget, GdkEvent* gdkEvent) {
 override void hookEvents () {
     super.hookEvents ();
     if (OS.GTK_VERSION >= OS.buildVERSION (2, 6, 0)) {
-        OS.g_signal_connect_closure (handle, OS.change_value.ptr, display.closures [CHANGE_VALUE], false);
+        OS.g_signal_connect_closure (handle, OS.change_value.ptr, display.getClosure (CHANGE_VALUE), false);
     }
-    OS.g_signal_connect_closure (handle, OS.value_changed.ptr, display.closures [VALUE_CHANGED], false);
+    OS.g_signal_connect_closure (handle, OS.value_changed.ptr, display.getClosure (VALUE_CHANGED), false);
 }
 
 override void register () {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Spinner.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Spinner.d
@@ -720,15 +720,15 @@ override int gtk_value_changed (int  adjustment) {
 
 override void hookEvents () {
     super.hookEvents();
-    OS.g_signal_connect_closure (handle, OS.changed.ptr, display.closures [CHANGED], true);
-    OS.g_signal_connect_closure (handle, OS.insert_text.ptr, display.closures [INSERT_TEXT], false);
-    OS.g_signal_connect_closure (handle, OS.delete_text.ptr, display.closures [DELETE_TEXT], false);
-    OS.g_signal_connect_closure (handle, OS.value_changed.ptr, display.closures [VALUE_CHANGED], false);
-    OS.g_signal_connect_closure (handle, OS.activate.ptr, display.closures [ACTIVATE], false);
-    OS.g_signal_connect_closure (handle, OS.populate_popup.ptr, display.closures [POPULATE_POPUP], false);
+    OS.g_signal_connect_closure (handle, OS.changed.ptr, display.getClosure (CHANGED), true);
+    OS.g_signal_connect_closure (handle, OS.insert_text.ptr, display.getClosure (INSERT_TEXT), false);
+    OS.g_signal_connect_closure (handle, OS.delete_text.ptr, display.getClosure (DELETE_TEXT), false);
+    OS.g_signal_connect_closure (handle, OS.value_changed.ptr, display.getClosure (VALUE_CHANGED), false);
+    OS.g_signal_connect_closure (handle, OS.activate.ptr, display.getClosure (ACTIVATE), false);
+    OS.g_signal_connect_closure (handle, OS.populate_popup.ptr, display.getClosure (POPULATE_POPUP), false);
     auto imContext = imContext ();
     if (imContext !is null) {
-        OS.g_signal_connect_closure (imContext, OS.commit.ptr, display.closures [COMMIT], false);
+        OS.g_signal_connect_closure (imContext, OS.commit.ptr, display.getClosure (COMMIT), false);
         int id = OS.g_signal_lookup (OS.commit.ptr, OS.gtk_im_context_get_type ());
         int mask =  OS.G_SIGNAL_MATCH_DATA | OS.G_SIGNAL_MATCH_ID;
         OS.g_signal_handlers_block_matched (imContext, mask, id, 0, null, null, cast(void*)handle);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TabFolder.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TabFolder.d
@@ -472,7 +472,7 @@ override int gtk_switch_page (GtkWidget* widget, ptrdiff_t page, ptrdiff_t page_
 
 override void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure (handle, OS.switch_page.ptr, display.closures [SWITCH_PAGE], false);
+    OS.g_signal_connect_closure (handle, OS.switch_page.ptr, display.getClosure (SWITCH_PAGE), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TabItem.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TabItem.d
@@ -229,8 +229,8 @@ override int gtk_mnemonic_activate (GtkWidget* widget, ptrdiff_t arg1) {
 
 override void hookEvents () {
     super.hookEvents ();
-    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.closures [ENTER_NOTIFY_EVENT], false);
+    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.getClosure (ENTER_NOTIFY_EVENT), false);
 }
 
 override void register () {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Table.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Table.d
@@ -2055,10 +2055,10 @@ void hideFirstColumn () {
 override void hookEvents () {
     super.hookEvents ();
     auto selection = OS.gtk_tree_view_get_selection(handle);
-    OS.g_signal_connect_closure (selection, OS.changed.ptr, display.closures [CHANGED], false);
-    OS.g_signal_connect_closure (handle, OS.row_activated.ptr, display.closures [ROW_ACTIVATED], false);
+    OS.g_signal_connect_closure (selection, OS.changed.ptr, display.getClosure (CHANGED), false);
+    OS.g_signal_connect_closure (handle, OS.row_activated.ptr, display.getClosure (ROW_ACTIVATED), false);
     if (checkRenderer !is null) {
-        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.closures [TOGGLED], false);
+        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.getClosure (TOGGLED), false);
     }
 }
 
@@ -2177,7 +2177,7 @@ void recreateRenderers () {
         if (checkRenderer is null) error (SWT.ERROR_NO_HANDLES);
         OS.g_object_ref (checkRenderer);
         display.addWidget (checkRenderer, this);
-        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.closures [TOGGLED], false);
+        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.getClosure (TOGGLED), false);
     }
     if (columnCount is 0) {
         createRenderers (OS.gtk_tree_view_get_column (handle, 0), Table.FIRST_COLUMN, true, 0);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TableColumn.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TableColumn.d
@@ -400,9 +400,9 @@ override int gtk_size_allocate (GtkWidget* widget, ptrdiff_t allocation) {
 
 override void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.closures [CLICKED], false);
-    if (buttonHandle !is null) OS.g_signal_connect_closure_by_id (buttonHandle, display.signalIds [SIZE_ALLOCATE], 0, display.closures [SIZE_ALLOCATE], false);
-    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
+    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.getClosure (CLICKED), false);
+    if (buttonHandle !is null) OS.g_signal_connect_closure_by_id (buttonHandle, display.signalIds [SIZE_ALLOCATE], 0, display.getClosure (SIZE_ALLOCATE), false);
+    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Text.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Text.d
@@ -1369,21 +1369,21 @@ override int gtk_text_buffer_insert_text (GtkTextBuffer *widget, GtkTextIter *it
 override void hookEvents () {
     super.hookEvents();
     if ((style & SWT.SINGLE) !is 0) {
-        OS.g_signal_connect_closure (handle, OS.changed.ptr, display.closures [CHANGED], true);
-        OS.g_signal_connect_closure (handle, OS.insert_text.ptr, display.closures [INSERT_TEXT], false);
-        OS.g_signal_connect_closure (handle, OS.delete_text.ptr, display.closures [DELETE_TEXT], false);
-        OS.g_signal_connect_closure (handle, OS.activate.ptr, display.closures [ACTIVATE], false);
-        OS.g_signal_connect_closure (handle, OS.grab_focus.ptr, display.closures [GRAB_FOCUS], false);
-        OS.g_signal_connect_closure (handle, OS.populate_popup.ptr, display.closures [POPULATE_POPUP], false);
+        OS.g_signal_connect_closure (handle, OS.changed.ptr, display.getClosure (CHANGED), true);
+        OS.g_signal_connect_closure (handle, OS.insert_text.ptr, display.getClosure (INSERT_TEXT), false);
+        OS.g_signal_connect_closure (handle, OS.delete_text.ptr, display.getClosure (DELETE_TEXT), false);
+        OS.g_signal_connect_closure (handle, OS.activate.ptr, display.getClosure (ACTIVATE), false);
+        OS.g_signal_connect_closure (handle, OS.grab_focus.ptr, display.getClosure (GRAB_FOCUS), false);
+        OS.g_signal_connect_closure (handle, OS.populate_popup.ptr, display.getClosure (POPULATE_POPUP), false);
     } else {
-        OS.g_signal_connect_closure (bufferHandle, OS.changed.ptr, display.closures [CHANGED], false);
-        OS.g_signal_connect_closure (bufferHandle, OS.insert_text.ptr, display.closures [TEXT_BUFFER_INSERT_TEXT], false);
-        OS.g_signal_connect_closure (bufferHandle, OS.delete_range.ptr, display.closures [DELETE_RANGE], false);
-        OS.g_signal_connect_closure (handle, OS.populate_popup.ptr, display.closures [POPULATE_POPUP], false);
+        OS.g_signal_connect_closure (bufferHandle, OS.changed.ptr, display.getClosure (CHANGED), false);
+        OS.g_signal_connect_closure (bufferHandle, OS.insert_text.ptr, display.getClosure (TEXT_BUFFER_INSERT_TEXT), false);
+        OS.g_signal_connect_closure (bufferHandle, OS.delete_range.ptr, display.getClosure (DELETE_RANGE), false);
+        OS.g_signal_connect_closure (handle, OS.populate_popup.ptr, display.getClosure (POPULATE_POPUP), false);
     }
     auto imContext = imContext ();
     if (imContext !is null) {
-        OS.g_signal_connect_closure (imContext, OS.commit.ptr, display.closures [COMMIT], false);
+        OS.g_signal_connect_closure (imContext, OS.commit.ptr, display.getClosure (COMMIT), false);
         int id = OS.g_signal_lookup (OS.commit.ptr, OS.gtk_im_context_get_type ());
         int mask =  OS.G_SIGNAL_MATCH_DATA | OS.G_SIGNAL_MATCH_ID;
         OS.g_signal_handlers_block_matched (imContext, mask, id, 0, null, null, cast(void*)handle);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ToolItem.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ToolItem.d
@@ -623,12 +623,12 @@ bool hasFocus () {
 override void hookEvents () {
     super.hookEvents ();
     if ((style & SWT.SEPARATOR) !is 0) return;
-    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.closures [CLICKED], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.closures [ENTER_NOTIFY_EVENT], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [LEAVE_NOTIFY_EVENT], 0, display.closures [LEAVE_NOTIFY_EVENT], false);
-    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
+    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.getClosure (CLICKED), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [ENTER_NOTIFY_EVENT], 0, display.getClosure (ENTER_NOTIFY_EVENT), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [LEAVE_NOTIFY_EVENT], 0, display.getClosure (LEAVE_NOTIFY_EVENT), false);
+    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
 
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [FOCUS_OUT_EVENT], 0, display.closures [FOCUS_OUT_EVENT], false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [FOCUS_OUT_EVENT], 0, display.getClosure (FOCUS_OUT_EVENT), false);
 
     /*
     * Feature in GTK.  Usually, GTK widgets propagate all events to their
@@ -645,12 +645,12 @@ override void hookEvents () {
         OS.GDK_KEY_PRESS_MASK | OS.GDK_KEY_RELEASE_MASK |
         OS.GDK_FOCUS_CHANGE_MASK;
     OS.gtk_widget_add_events (handle, mask);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.closures [BUTTON_RELEASE_EVENT], false);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [EVENT_AFTER], 0, display.closures[EVENT_AFTER], false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_RELEASE_EVENT], 0, display.getClosure (BUTTON_RELEASE_EVENT), false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [EVENT_AFTER], 0, display.getClosure (EVENT_AFTER), false);
 
     auto topHandle = topHandle ();
-    OS.g_signal_connect_closure_by_id (topHandle, display.signalIds [MAP], 0, display.closures [MAP], true);
+    OS.g_signal_connect_closure_by_id (topHandle, display.signalIds [MAP], 0, display.getClosure (MAP), true);
 }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ToolTip.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/ToolTip.d
@@ -532,15 +532,15 @@ override int gtk_size_allocate (GtkWidget* widget, ptrdiff_t allocation) {
 
 override void hookEvents () {
     if ((style & SWT.BALLOON) !is 0) {
-        OS.g_signal_connect_closure (handle, OS.expose_event.ptr, display.closures [EXPOSE_EVENT], false);
+        OS.g_signal_connect_closure (handle, OS.expose_event.ptr, display.getClosure (EXPOSE_EVENT), false);
         OS.gtk_widget_add_events (handle, OS.GDK_BUTTON_PRESS_MASK);
-        OS.g_signal_connect_closure (handle, OS.button_press_event.ptr, display.closures [BUTTON_PRESS_EVENT], false);
+        OS.g_signal_connect_closure (handle, OS.button_press_event.ptr, display.getClosure (BUTTON_PRESS_EVENT), false);
     } else {
         auto tipWindow = OS.GTK_TOOLTIPS_TIP_WINDOW (cast(GtkTooltips*)handle);
         if (tipWindow !is null) {
-            OS.g_signal_connect_closure (tipWindow, OS.size_allocate.ptr, display.closures [SIZE_ALLOCATE], false);
+            OS.g_signal_connect_closure (tipWindow, OS.size_allocate.ptr, display.getClosure (SIZE_ALLOCATE), false);
             OS.gtk_widget_add_events (tipWindow, OS.GDK_BUTTON_PRESS_MASK);
-            OS.g_signal_connect_closure (tipWindow, OS.button_press_event.ptr, display.closures [BUTTON_PRESS_EVENT], false);
+            OS.g_signal_connect_closure (tipWindow, OS.button_press_event.ptr, display.getClosure (BUTTON_PRESS_EVENT), false);
         }
     }
 }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TrayItem.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TrayItem.d
@@ -307,8 +307,8 @@ override int gtk_size_allocate (GtkWidget* widget, ptrdiff_t allocation) {
 override void hookEvents () {
     int eventMask = OS.GDK_BUTTON_PRESS_MASK;
     OS.gtk_widget_add_events (handle, eventMask);
-    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.closures [BUTTON_PRESS_EVENT], false);
-    OS.g_signal_connect_closure_by_id (imageHandle, display.signalIds [SIZE_ALLOCATE], 0, display.closures [SIZE_ALLOCATE], false);
+    OS.g_signal_connect_closure_by_id (handle, display.signalIds [BUTTON_PRESS_EVENT], 0, display.getClosure (BUTTON_PRESS_EVENT), false);
+    OS.g_signal_connect_closure_by_id (imageHandle, display.signalIds [SIZE_ALLOCATE], 0, display.getClosure (SIZE_ALLOCATE), false);
  }
 
 /**

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Tree.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Tree.d
@@ -2154,13 +2154,13 @@ void hideFirstColumn () {
 override void hookEvents () {
     super.hookEvents ();
     auto selection = OS.gtk_tree_view_get_selection(handle);
-    OS.g_signal_connect_closure (selection, OS.changed.ptr, display.closures [CHANGED], false);
-    OS.g_signal_connect_closure (handle, OS.row_activated.ptr, display.closures [ROW_ACTIVATED], false);
-    OS.g_signal_connect_closure (handle, OS.test_expand_row.ptr, display.closures [TEST_EXPAND_ROW], false);
-    OS.g_signal_connect_closure (handle, OS.test_collapse_row.ptr, display.closures [TEST_COLLAPSE_ROW], false);
-    OS.g_signal_connect_closure (handle, OS.expand_collapse_cursor_row.ptr, display.closures [EXPAND_COLLAPSE_CURSOR_ROW], false);
+    OS.g_signal_connect_closure (selection, OS.changed.ptr, display.getClosure (CHANGED), false);
+    OS.g_signal_connect_closure (handle, OS.row_activated.ptr, display.getClosure (ROW_ACTIVATED), false);
+    OS.g_signal_connect_closure (handle, OS.test_expand_row.ptr, display.getClosure (TEST_EXPAND_ROW), false);
+    OS.g_signal_connect_closure (handle, OS.test_collapse_row.ptr, display.getClosure (TEST_COLLAPSE_ROW), false);
+    OS.g_signal_connect_closure (handle, OS.expand_collapse_cursor_row.ptr, display.getClosure (EXPAND_COLLAPSE_CURSOR_ROW), false);
     if (checkRenderer !is null) {
-        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.closures [TOGGLED], false);
+        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.getClosure (TOGGLED), false);
     }
 }
 
@@ -2258,7 +2258,7 @@ void recreateRenderers () {
         if (checkRenderer is null) error (SWT.ERROR_NO_HANDLES);
         OS.g_object_ref (checkRenderer);
         display.addWidget (cast(GtkWidget*)checkRenderer, this);
-        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.closures [TOGGLED], false);
+        OS.g_signal_connect_closure (checkRenderer, OS.toggled.ptr, display.getClosure (TOGGLED), false);
     }
     if (columnCount is 0) {
         createRenderers (OS.gtk_tree_view_get_column (handle, 0), Tree.FIRST_COLUMN, true, 0);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TreeColumn.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/TreeColumn.d
@@ -406,9 +406,9 @@ override int gtk_size_allocate (GtkWidget* widget, ptrdiff_t allocation) {
 override
 void hookEvents () {
     super.hookEvents ();
-    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.closures [CLICKED], false);
-    if (buttonHandle !is null) OS.g_signal_connect_closure_by_id (buttonHandle, display.signalIds [SIZE_ALLOCATE], 0, display.closures [SIZE_ALLOCATE], false);
-    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.closures [MNEMONIC_ACTIVATE], false);
+    OS.g_signal_connect_closure (handle, OS.clicked.ptr, display.getClosure (CLICKED), false);
+    if (buttonHandle !is null) OS.g_signal_connect_closure_by_id (buttonHandle, display.signalIds [SIZE_ALLOCATE], 0, display.getClosure (SIZE_ALLOCATE), false);
+    if (labelHandle !is null) OS.g_signal_connect_closure_by_id (labelHandle, display.signalIds [MNEMONIC_ACTIVATE], 0, display.getClosure (MNEMONIC_ACTIVATE), false);
 }
 
 /**

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetDwtBitmapV4.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetDwtBitmapV4.d
@@ -38,7 +38,7 @@ dub.sdl:
  * Author: kntroh
  * License: CC0(http://creativecommons.org/publicdomain/zero/1.0/)
  */
-module org.eclipse.swt.snippets.SnippetDwt1;
+module org.eclipse.swt.snippets.SnippetDwtBitmapV4;
 
 /**
  * This program snippet is the test of displaying RLE4 bitmap and V4 Header bitmap.

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetManyWidget.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetManyWidget.d
@@ -38,7 +38,7 @@ dub.sdl:
  * Author: kntroh
  * License: CC0(http://creativecommons.org/publicdomain/zero/1.0/)
  */
-module org.eclipse.swt.snippets.SnippetDwt1;
+module org.eclipse.swt.snippets.SnippetManyWidget;
 
 /**
  * This program snippet is a test for many widgets creation on GTK.

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetManyWidget.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetManyWidget.d
@@ -1,0 +1,64 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet_many_widgets"
+    dependency "dwt" path="../../../../../../"
+    stringImportPaths "../../../../../res"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gnomeui-2" \
+      "gnomevfs-2" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+
+/**
+ * Author: kntroh
+ * License: CC0(http://creativecommons.org/publicdomain/zero/1.0/)
+ */
+module org.eclipse.swt.snippets.SnippetDwt1;
+
+/**
+ * This program snippet is a test for many widgets creation on GTK.
+ */
+import org.eclipse.swt.all;
+
+void main() {
+    auto d = new Display;
+    auto s = new Shell(d);
+
+    foreach (i; 0 .. 4097) {
+        new Label(s, SWT.NONE);
+    }
+
+    s.open();
+    while (!s.isDisposed()) {
+        if (!d.readAndDispatch()) {
+            d.sleep();
+        }
+    }
+    d.dispose();
+}
+


### PR DESCRIPTION
An assertion error occurred when more than 1024 widgets were created. There was a problem with this code:

    void addWidget (GtkWidget* handle, Widget widget) {
        if (handle is null) return;
            if (freeSlot is -1) {
                ptrdiff_t len = freeSlot = indexTable.length + GROW_SIZE;
                ptrdiff_t[] newIndexTable = new ptrdiff_t[len];
                Widget[] newWidgetTable = new Widget [len];
                System.arraycopy (indexTable, 0, newIndexTable, 0, freeSlot);

In this process, the freeSlot should be array length before expansion, but it is actually length after expansion.
The SWT is as follows:

     int len = (freeSlot = indexTable.length) + GROW_SIZE;

I did the same and it was resolved.

---

I was creating and testing lot of widgets and got this error:

    GLib-GObject-CRITICAL **: g_closure_add_invalidate_notifier: assertion `closure->n_inotifiers < CLOSURE_MAX_N_INOTIFIERS' failed

This was due to a specification change in Glib 2.36.0, which was resolved in the SWT: https://bugs.eclipse.org/bugs/show_bug.cgi?id=407077
I've ported the SWT fix.