### PR TITLE
A module constructors must be extern(D).

### DIFF
--- a/base/src/java/lang/util.d
+++ b/base/src/java/lang/util.d
@@ -467,7 +467,7 @@ version( D_Version2 ) {
 }
 
 template sharedStaticThis(String content) {
-    const sharedStaticThis = prefixedIfD2!("shared", "static this()" ~ content);
+    const sharedStaticThis = prefixedIfD2!("extern(D) shared", "static this()" ~ content);
 }
 
 template sharedStatic_This(String content) {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/glx.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/glx.d
@@ -115,7 +115,7 @@ extern (C) Bool function(void *, GLint *, GLint *)dwt_glXQueryExtension;"
 ));
 
 Symbol[] symbols;
-static this () {
+extern(D) static this () {
     symbols = [
         Symbol("glGetIntegerv", cast(void**)& dwt_glGetIntegerv),
         Symbol("glViewport", cast(void**)& dwt_glViewport),

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/gtk.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/c/gtk.d
@@ -9713,7 +9713,7 @@ alias extern (C) void function(aGtkWidget *, gboolean)TGTKgtk_widget_set_receive
 ));
 
 extern(D) Symbol[] symbols;
-static this () {
+extern(D) static this () {
     symbols = [
         Symbol( "gtk_vseparator_new",  cast(void**)& gtk_vseparator_new),
         Symbol( "gtk_vseparator_get_type",  cast(void**)& gtk_vseparator_get_type),


### PR DESCRIPTION
Fixes for dmd 2.092.0.

Module constructors must be extern(D).
I fixed static this() where linkage is extern(C) or extern(Windows).