### PR TITLE
Custom drawing of Table is broken on Windows 64-bit.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -38,6 +38,7 @@ configuration "windows-win32" {
     "org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/mozilla/*"
 
   lflags `+$DWT_PACKAGE_DIR\org.eclipse.swt.win32.win32.x86\lib\` platform="x86"
+  lflags `/exet:nt/su:console:4.0` platform="x86"
   libs "olepro32" platform="x86"
   libs \
     "advapi32" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetPaintItem.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetPaintItem.d
@@ -1,0 +1,136 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet_paint_item"
+    dependency "dwt" path="../../../../../../"
+    stringImportPaths "../../../../../res"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gnomeui-2" \
+      "gnomevfs-2" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+
+/**
+ * Author: kntroh
+ * License: CC0(http://creativecommons.org/publicdomain/zero/1.0/)
+ */
+module org.eclipse.swt.snippets.SnippetPaintItem;
+
+/*
+ * Example for custom drawing a TableItem.
+ *
+ * For more information on custom drawing, see the this articles:
+ * https://www.eclipse.org/articles/article.php?file=Article-CustomDrawingTableAndTreeItems/index.html
+ */
+
+import org.eclipse.swt.all;
+
+import java.io.ByteArrayInputStream;
+import java.lang.all;
+
+void main() {
+    auto d = new Display;
+    auto s = new Shell(d);
+    s.setText("SnippetPaintItem");
+    s.setLayout(new FillLayout);
+    s.setSize(200, 150);
+
+    auto table = new Table(s, SWT.FULL_SELECTION);
+    table.setHeaderVisible(true);
+    auto column0 = new TableColumn(table, SWT.NONE);
+    column0.setText("Column0");
+    column0.setWidth(80);
+    auto column1 = new TableColumn(table, SWT.NONE);
+    column1.setText("Column1");
+    column1.setWidth(80);
+
+    auto image = new Image(d, new ImageData(new ByteArrayInputStream(cast(byte[])import("eclipse.png"))));
+    auto item0 = new TableItem(table, SWT.NONE);
+    item0.setImage(0, image);
+    item0.setText(0, "TableItem - 0-0");
+    item0.setText(1, "TableItem - 0-1");
+    auto item1 = new TableItem(table, SWT.NONE);
+    item1.setImage(1, image);
+    item1.setText(0, "TableItem - 1-0");
+    item1.setText(1, "TableItem - 1-1");
+    auto item2 = new TableItem(table, SWT.NONE);
+    item2.setText(0, "TableItem - 2-0");
+    item2.setText(1, "TableItem - 2-1");
+
+    table.addListener(SWT.EraseItem, new class Listener {
+        override void handleEvent(Event e) {
+            e.gc.fillRectangle(e.x, e.y, e.width, e.height);
+            e.detail = e.detail & ~SWT.FOREGROUND;
+        }
+    });
+    table.addListener(SWT.PaintItem, new class Listener {
+        override void handleEvent(Event e) {
+            auto item = cast(TableItem)e.item;
+            auto column = e.index;
+            auto index = table.indexOf(item);
+            auto image = item.getImage(column);
+            if (image) {
+                auto imageBounds = item.getImageBounds(column);
+                auto iconBounds = image.getBounds();
+                if (column == 1) {
+                    e.gc.setAlpha(128);
+                }
+                e.gc.drawImage(image, imageBounds.x, imageBounds.y + (imageBounds.height - iconBounds.height) / 2);
+                e.gc.setAlpha(255);
+            }
+            auto textBounds = item.getTextBounds(column);
+            string text;
+            switch (index) {
+            case 0:
+                text = "one";
+                break;
+            case 1:
+                text = "two";
+                break;
+            case 2:
+                text = "three";
+                break;
+            default:
+                assert (0);
+            }
+            if (column == 1) {
+                text = "sub-" ~ text;
+            }
+            auto textHeight = e.gc.textExtent(text).y;
+            e.gc.drawText(text, textBounds.x, textBounds.y + (textBounds.height - textHeight) / 2, true);
+        }
+    });
+
+    s.open();
+    while (!s.isDisposed()) {
+        if (!d.readAndDispatch()) {
+            d.sleep();
+        }
+    }
+    image.dispose();
+    d.dispose();
+}

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Table.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Table.d
@@ -494,7 +494,7 @@ LRESULT CDDS_ITEMPOSTPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) 
     if (!ignoreCustomDraw && !ignoreDrawFocus && nmcd.nmcd.rc.left !is nmcd.nmcd.rc.right) {
         if (OS.IsWindowVisible (handle) && OS.IsWindowEnabled (handle)) {
             if (!explorerTheme && (style & SWT.FULL_SELECTION) !is 0) {
-                if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
+                if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
                     auto dwExStyle = OS.SendMessage (handle, OS.LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0);
                     if ((dwExStyle & OS.LVS_EX_FULLROWSELECT) is 0) {
 //                      if ((nmcd.uItemState & OS.CDIS_FOCUS) !is 0) {
@@ -548,7 +548,7 @@ LRESULT CDDS_ITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
     if (!ignoreCustomDraw) {
         if (OS.IsWindowVisible (handle) && OS.IsWindowEnabled (handle)) {
             if (!explorerTheme && (style & SWT.FULL_SELECTION) !is 0) {
-                if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
+                if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
                     auto dwExStyle = OS.SendMessage (handle, OS.LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0);
                     if ((dwExStyle & OS.LVS_EX_FULLROWSELECT) is 0) {
                         if ((nmcd.nmcd.uItemState & OS.CDIS_FOCUS) !is 0) {
@@ -584,7 +584,7 @@ LRESULT CDDS_POSTPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
     */
     if (--customCount is 0 && OS.IsWindowVisible (handle)) {
         if (!explorerTheme && (style & SWT.FULL_SELECTION) !is 0) {
-            if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
+            if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
                 auto dwExStyle = OS.SendMessage (handle, OS.LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0);
                 if ((dwExStyle & OS.LVS_EX_FULLROWSELECT) is 0) {
                     int bits = OS.LVS_EX_FULLROWSELECT;
@@ -636,7 +636,7 @@ LRESULT CDDS_PREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
     */
     if (customCount++ is 0 && OS.IsWindowVisible (handle)) {
         if (!explorerTheme && (style & SWT.FULL_SELECTION) !is 0) {
-            if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
+            if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
                 auto dwExStyle = OS.SendMessage (handle, OS.LVM_GETEXTENDEDLISTVIEWSTYLE, 0, 0);
                 if ((dwExStyle & OS.LVS_EX_FULLROWSELECT) !is 0) {
                     int bits = OS.LVS_EX_FULLROWSELECT;
@@ -697,7 +697,7 @@ LRESULT CDDS_PREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam) {
                 OS.SetRect (&rect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.right, nmcd.nmcd.rc.bottom);
                 fillImageBackground (nmcd.nmcd.hdc, control, &rect);
             } else {
-                if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
+                if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
                     if (OS.IsWindowEnabled (handle)) {
                         RECT rect;
                         OS.SetRect (&rect, nmcd.nmcd.rc.left, nmcd.nmcd.rc.top, nmcd.nmcd.rc.right, nmcd.nmcd.rc.bottom);
@@ -743,7 +743,7 @@ LRESULT CDDS_SUBITEMPOSTPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lPara
         * is to clear the sort column in CDDS_SUBITEMPREPAINT, and reset it
         * in CDDS_SUBITEMPOSTPAINT.
         */
-        if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
+        if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
             if ((sortDirection & (SWT.UP | SWT.DOWN)) !is 0) {
                 if (sortColumn !is null && !sortColumn.isDisposed ()) {
                     auto oldColumn = OS.SendMessage (handle, OS.LVM_GETSELECTEDCOLUMN, 0, 0);
@@ -810,7 +810,7 @@ LRESULT CDDS_SUBITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam
             if (isDisposed () || item.isDisposed ()) return null;
         }
         if (hooks (SWT.EraseItem)) {
-            sendEraseItemEvent (item, nmcd, cast(int)/*64bit*/lParam, measureEvent);
+            sendEraseItemEvent (item, nmcd, lParam, measureEvent);
             if (isDisposed () || item.isDisposed ()) return null;
             code |= OS.CDRF_NOTIFYPOSTPAINT;
         }
@@ -898,7 +898,7 @@ LRESULT CDDS_SUBITEMPREPAINT (NMLVCUSTOMDRAW* nmcd, WPARAM wParam, LPARAM lParam
                         Control control = findBackgroundControl ();
                         if (control is null) control = this;
                         if (control.backgroundImage is null) {
-                            if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
+                            if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
                                 nmcd.clrTextBk = control.getBackgroundPixel ();
                             }
                         }
@@ -3271,7 +3271,7 @@ public void selectAll () {
     ignoreSelect = false;
 }
 
-void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, int lParam, Event measureEvent) {
+void sendEraseItemEvent (TableItem item, NMLVCUSTOMDRAW* nmcd, LPARAM lParam, Event measureEvent) {
     auto hDC = nmcd.nmcd.hdc;
     int clrText = item.cellForeground !is null ? item.cellForeground [nmcd.iSubItem] : -1;
     if (clrText is -1) clrText = item.foreground;
@@ -3834,7 +3834,7 @@ void setBackgroundImage (HBITMAP hBitmap) {
 }
 
 override void setBackgroundPixel (int newPixel) {
-    auto oldPixel = OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0);
+    auto oldPixel = cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0);
     if (oldPixel !is OS.CLR_NONE) {
         if (findImageControl () !is null) return;
         if (newPixel is -1) newPixel = defaultBackground ();
@@ -3867,7 +3867,7 @@ void setBackgroundTransparent (bool transparent) {
     * other custom drawing.  The fix is to clear the selected
     * column.
     */
-    auto oldPixel = OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0);
+    auto oldPixel = cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0);
     if (transparent) {
         if (oldPixel !is OS.CLR_NONE) {
             /*
@@ -5831,7 +5831,7 @@ override LRESULT WM_PAINT (WPARAM wParam, LPARAM lParam) {
                     OS.SetBrushOrgEx (hDC, ps.rcPaint.left, ps.rcPaint.top, &lpPoint2);
                     auto hBitmap = OS.CreateCompatibleBitmap (paintDC, width, height);
                     auto hOldBitmap = OS.SelectObject (hDC, hBitmap);
-                    if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
+                    if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
                         RECT rect;
                         OS.SetRect (&rect, ps.rcPaint.left, ps.rcPaint.top, ps.rcPaint.right, ps.rcPaint.bottom);
                         drawBackground (hDC, &rect);
@@ -5971,7 +5971,7 @@ override LRESULT WM_SETREDRAW (WPARAM wParam, LPARAM lParam) {
     * turned off.
     */
     if (wParam is 1) {
-        if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
+        if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
             if (hooks (SWT.MeasureItem) || hooks (SWT.EraseItem) || hooks (SWT.PaintItem)) {
                 OS.SendMessage (handle, OS.LVM_SETBKCOLOR, 0, OS.CLR_NONE);
             }
@@ -5979,7 +5979,7 @@ override LRESULT WM_SETREDRAW (WPARAM wParam, LPARAM lParam) {
     }
     auto code = callWindowProc (handle, OS.WM_SETREDRAW, wParam, lParam);
     if (wParam is 0) {
-        if (OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
+        if (cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0) is OS.CLR_NONE) {
             OS.SendMessage (handle, OS.LVM_SETBKCOLOR, 0, 0xFFFFFF);
         }
     }
@@ -6004,7 +6004,7 @@ override LRESULT WM_SYSCOLORCHANGE (WPARAM wParam, LPARAM lParam) {
     if (findBackgroundControl () is null) {
         setBackgroundPixel (defaultBackground ());
     } else {
-        auto oldPixel = OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0);
+        auto oldPixel = cast(int)OS.SendMessage (handle, OS.LVM_GETBKCOLOR, 0, 0);
         if (oldPixel !is OS.CLR_NONE) {
             if (findImageControl () is null) {
                 if ((style & SWT.CHECK) !is 0) fixCheckboxImageListColor (true);
@@ -6435,6 +6435,7 @@ override LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
         case OS.NM_CUSTOMDRAW: {
             auto hwndHeader = cast(HWND) OS.SendMessage (handle, OS.LVM_GETHEADER, 0, 0);
             if (hdr.hwndFrom is hwndHeader) break;
+
             if (!customDraw && findImageControl () is null) {
                 /*
                 * Feature in Windows.  When the table is disabled, it draws

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TableColumn.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/TableColumn.d
@@ -746,7 +746,7 @@ void setSortDirection (int direction) {
         parent.forceResize ();
         RECT rect;
         OS.GetClientRect (hwnd, &rect);
-        if (OS.SendMessage (hwnd, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
+        if (cast(int)OS.SendMessage (hwnd, OS.LVM_GETBKCOLOR, 0, 0) !is OS.CLR_NONE) {
             auto oldColumn = OS.SendMessage (hwnd, OS.LVM_GETSELECTEDCOLUMN, 0, 0);
             int newColumn = direction is SWT.NONE ? -1 : index;
             OS.SendMessage (hwnd, OS.LVM_SETSELECTEDCOLUMN, newColumn, 0);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Tree.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Tree.d
@@ -297,7 +297,7 @@ TreeItem _getItem (HANDLE hItem, LPARAM id) {
 }
 
 void _setBackgroundPixel (int newPixel) {
-    auto oldPixel = OS.SendMessage (handle, OS.TVM_GETBKCOLOR, 0, 0);
+    auto oldPixel = cast(int)OS.SendMessage (handle, OS.TVM_GETBKCOLOR, 0, 0);
     if (oldPixel !is newPixel) {
         /*
         * Bug in Windows.  When TVM_SETBKCOLOR is used more
@@ -4454,7 +4454,7 @@ override void setBackgroundImage (HBITMAP hBitmap) {
         * it is already the default) to make Windows use the
         * brush.
         */
-        if (OS.SendMessage (handle, OS.TVM_GETBKCOLOR, 0, 0) is -1) {
+        if (cast(int)OS.SendMessage (handle, OS.TVM_GETBKCOLOR, 0, 0) is -1) {
             OS.SendMessage (handle, OS.TVM_SETBKCOLOR, 0, -1);
         }
         _setBackgroundPixel (-1);


### PR DESCRIPTION
I found a bugs when I used the `Table` custom drawing.

 * A 8-bit value returned by SendMessage(64) is compared to `OS.CLR_NONE`(0xffffffff) without conversion to `COLOREF`(4-bit). I had same problem with `Tree`, so I fixed it.
 * There was still a part where a pointer which is LPARAM was cast to int.

And a table header were not shown with Windows 32-bit build. Need a linker flag of Windows Subsystem.