### PR TITLE
Build fails with LDC(x86) on Windows.

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -37,8 +37,8 @@ configuration "windows-win32" {
   excludedSourceFiles \
     "org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/mozilla/*"
 
-  lflags `+$DWT_PACKAGE_DIR\org.eclipse.swt.win32.win32.x86\lib\` platform="x86"
-  lflags `/exet:nt/su:console:4.0` platform="x86"
+  lflags `+$DWT_PACKAGE_DIR\org.eclipse.swt.win32.win32.x86\lib\` platform="x86-dmd"
+  lflags `/exet:nt/su:console:4.0` platform="x86-dmd"
   libs "olepro32" platform="x86"
   libs \
     "advapi32" \


### PR DESCRIPTION
Because LDC uses Microsoft's linker, the flags for OPTLINK cause problems.