### PR TITLE
A functions with same name are declared with extern(D).

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/win32/WINTYPES.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/internal/win32/WINTYPES.d
@@ -15415,6 +15415,7 @@ struct SCRIPT_ANALYSIS {
     WORD BITS;
     SCRIPT_STATE s;
 
+extern(D):
     // getter
     uint eScript()      { return BITS & 0x03FFU; }
     uint fRTL()         { return btvg(&BITS, 10); }
@@ -15441,6 +15442,7 @@ align(1):
     BYTE BITS;
     BYTE fReserved;
 
+extern(D):
     // getter
     uint fContextDigits()       { return btvg(&BITS, 0); }
     uint fInvertPreBoundDir()   { return btvg(&BITS, 1); }
@@ -15479,6 +15481,7 @@ struct SCRIPT_LOGATTR {
 align(1):
     BYTE BITS;
 
+extern(D):
     // gettter
     uint fSoftBreak()   { return btvg(&BITS, 0); }
     uint fWhiteSpace()  { return btvg(&BITS, 1); }
@@ -15500,6 +15503,7 @@ struct SCRIPT_PROPERTIES {
     DWORD   BITS1;
     DWORD   BITS2;
 
+extern(D):
     uint langid()   { return BITS1 >> 16; }
     uint fNumeric() { return btvg(&BITS1, 16); }
     uint fComplex() { return btvg(&BITS1, 17); }
@@ -15536,6 +15540,8 @@ struct SCRIPT_PROPERTIES {
 
 struct SCRIPT_STATE {
     WORD BITS;
+
+extern(D):
     // getter
     uint uBidiLevel()           { return (BITS & 0x1F);}
     uint fOverrideDirection()   { return btvg(&BITS, 5); }
@@ -15568,6 +15574,7 @@ align(1):
     BYTE BITS;
     BYTE fShapeReserved;
 
+extern(D):
     // getter
     uint uJustification()   { return BITS & 0x0F; }
     uint fClusterStart()    { return btvg(&BITS, 4); }


### PR DESCRIPTION
https://dlang.org/changelog/2.095.0.html#duplicate-implementations-deprecation
Since these functions are prepared to reproduce bitfields, there is no problem in changing a calling convention.
For example, the following C structure:
```C
typedef struct tag_SCRIPT_ANALYSIS {
  WORD         eScript : 10;
  WORD         fRTL : 1;
  WORD         fLayoutRTL : 1;
  WORD         fLinkBefore : 1;
  WORD         fLinkAfter : 1;
  WORD         fLogicalOrder : 1;
  WORD         fNoGlyphIndex : 1;
  SCRIPT_STATE s;
} SCRIPT_ANALYSIS;
```

This structure is reproduced as follows:
```D
struct SCRIPT_ANALYSIS {
    WORD BITS;
    SCRIPT_STATE s;

extern(D):
    // getter
    uint eScript()      { return BITS & 0x03FFU; }
    uint fRTL()         { return btvg(&BITS, 10); }
    uint fLayoutRTL()   { return btvg(&BITS, 11); }
    uint fLinkBefore()  { return btvg(&BITS, 12); }
    uint fLinkAfter()   { return btvg(&BITS, 13); }
    uint fLogicalOrder(){ return btvg(&BITS, 14); }
    uint fNoGlyphIndex(){ return btvg(&BITS, 15); }
    // setter
    void eScript(uint val)      { BITS &= 0xFC00; BITS |= (val & 0x03FF); }
    void fRTL(uint val)         { btvs(&BITS, 10, val); }
    void fLayoutRTL(uint val)   { btvs(&BITS, 11, val); }
    void fLinkBefore(uint val)  { btvs(&BITS, 12, val); }
    void fLinkAfter(uint val)   { btvs(&BITS, 13, val); }
    void fLogicalOrder(uint val){ btvs(&BITS, 14, val); }
    void fNoGlyphIndex(uint val){ btvs(&BITS, 15, val); }
}
```