### PR TITLE
[Gtk] Fix usage of deprecated methods.

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/custom/StyledText.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/custom/StyledText.d
@@ -7314,7 +7314,7 @@ public void setKeyBinding(int key, int action) {
     checkWidget();
     int modifierValue = key & SWT.MODIFIER_MASK;
     char keyChar = cast(char)(key & SWT.KEY_MASK);
-    if (Compatibility.isLetter(keyChar)) {
+    if (Character.isLetter(keyChar)) {
         // make the keybinding case insensitive by adding it
         // in its upper and lower case form
         char ch = cast(char) CharacterToUpper(keyChar);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Device.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Device.d
@@ -22,7 +22,6 @@ import org.eclipse.swt.graphics.Font;
 import org.eclipse.swt.graphics.GCData;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
-import org.eclipse.swt.internal.Compatibility;
 import org.eclipse.swt.internal.gtk.OS;
 import java.lang.all;
 
@@ -275,7 +274,7 @@ static Device findDevice (void* xDisplay) {
 }
 
 static void deregister (Device device) {
-    synchronized {   
+    synchronized {
         for (int i=0; i<Devices.length; i++) {
             if (device is Devices [i]) Devices [i] = null;
         }
@@ -436,7 +435,7 @@ public FontData[] getFontList (String faceName, bool scalable) {
         bool match = true;
         if (faceName !is null) {
             auto familyName = OS.pango_font_family_get_name(family);
-            match = Compatibility.equalsIgnoreCase(faceName, fromStringz( familyName ));
+            match = faceName.equalsIgnoreCase(fromStringz(familyName));
         }
         if (match) {
             OS.pango_font_family_list_faces(family, &faces, &n_faces);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/GC.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/GC.d
@@ -40,7 +40,6 @@ import org.eclipse.swt.graphics.LineAttributes;
 import org.eclipse.swt.internal.gtk.OS;
 import org.eclipse.swt.internal.cairo.Cairo : Cairo;
 import org.eclipse.swt.internal.Converter;
-import org.eclipse.swt.internal.Compatibility;
 import java.lang.all;
 
 version(Tango){
@@ -673,18 +672,18 @@ public void drawArc(int x, int y, int width, int height, int startAngle, int arc
         double xOffset = data.cairoXoffset, yOffset = data.cairoYoffset;
         if (width is height) {
             if (arcAngle >= 0) {
-                Cairo.cairo_arc_negative(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f, width / 2f, -startAngle * cast(float)Compatibility.PI / 180, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc_negative(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f, width / 2f, -startAngle * cast(float)Math.PI / 180, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             } else {
-                Cairo.cairo_arc(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f, width / 2f, -startAngle * cast(float)Compatibility.PI / 180, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f, width / 2f, -startAngle * cast(float)Math.PI / 180, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             }
         } else {
             Cairo.cairo_save(cairo);
             Cairo.cairo_translate(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f);
             Cairo.cairo_scale(cairo, width / 2f, height / 2f);
             if (arcAngle >= 0) {
-                Cairo.cairo_arc_negative(cairo, 0, 0, 1, -startAngle * cast(float)Compatibility.PI / 180, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc_negative(cairo, 0, 0, 1, -startAngle * cast(float)Math.PI / 180, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             } else {
-                Cairo.cairo_arc(cairo, 0, 0, 1, -startAngle * cast(float)Compatibility.PI / 180, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc(cairo, 0, 0, 1, -startAngle * cast(float)Math.PI / 180, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             }
             Cairo.cairo_restore(cairo);
         }
@@ -1222,12 +1221,12 @@ public void drawOval(int x, int y, int width, int height) {
     if (cairo !is null) {
         double xOffset = data.cairoXoffset, yOffset = data.cairoYoffset;
         if (width is height) {
-            Cairo.cairo_arc_negative(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f, width / 2f, 0, -2 * cast(float)Compatibility.PI);
+            Cairo.cairo_arc_negative(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f, width / 2f, 0, -2 * cast(float)Math.PI);
         } else {
             Cairo.cairo_save(cairo);
             Cairo.cairo_translate(cairo, x + xOffset + width / 2f, y + yOffset + height / 2f);
             Cairo.cairo_scale(cairo, width / 2f, height / 2f);
-            Cairo.cairo_arc_negative(cairo, 0, 0, 1, 0, -2 * cast(float)Compatibility.PI);
+            Cairo.cairo_arc_negative(cairo, 0, 0, 1, 0, -2 * cast(float)Math.PI);
             Cairo.cairo_restore(cairo);
         }
         Cairo.cairo_stroke(cairo);
@@ -1483,10 +1482,10 @@ public void drawRoundRectangle(int x, int y, int width, int height, int arcWidth
             Cairo.cairo_translate(cairo, nx + xOffset, ny + yOffset);
             Cairo.cairo_scale(cairo, naw2, nah2);
             Cairo.cairo_move_to(cairo, fw - 1, 0);
-            Cairo.cairo_arc(cairo, fw - 1, 1, 1, Compatibility.PI + Compatibility.PI/2.0, Compatibility.PI*2.0);
-            Cairo.cairo_arc(cairo, fw - 1, fh - 1, 1, 0, Compatibility.PI/2.0);
-            Cairo.cairo_arc(cairo, 1, fh - 1, 1, Compatibility.PI/2, Compatibility.PI);
-            Cairo.cairo_arc(cairo, 1, 1, 1, Compatibility.PI, 270.0*Compatibility.PI/180.0);
+            Cairo.cairo_arc(cairo, fw - 1, 1, 1, Math.PI + Math.PI/2.0, Math.PI*2.0);
+            Cairo.cairo_arc(cairo, fw - 1, fh - 1, 1, 0, Math.PI/2.0);
+            Cairo.cairo_arc(cairo, 1, fh - 1, 1, Math.PI/2, Math.PI);
+            Cairo.cairo_arc(cairo, 1, 1, 1, Math.PI, 270.0*Math.PI/180.0);
             Cairo.cairo_close_path(cairo);
             Cairo.cairo_restore(cairo);
         }
@@ -1774,9 +1773,9 @@ public void fillArc(int x, int y, int width, int height, int startAngle, int arc
     if (cairo !is null) {
         if (width is height) {
             if (arcAngle >= 0) {
-                Cairo.cairo_arc_negative(cairo, x + width / 2f, y + height / 2f, width / 2f, -startAngle * cast(float)Compatibility.PI / 180,  -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc_negative(cairo, x + width / 2f, y + height / 2f, width / 2f, -startAngle * cast(float)Math.PI / 180,  -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             } else {
-                Cairo.cairo_arc(cairo, x + width / 2f, y + height / 2f, width / 2f, -startAngle * cast(float)Compatibility.PI / 180,  -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc(cairo, x + width / 2f, y + height / 2f, width / 2f, -startAngle * cast(float)Math.PI / 180,  -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             }
             Cairo.cairo_line_to(cairo, x + width / 2f, y + height / 2f);
         } else {
@@ -1784,9 +1783,9 @@ public void fillArc(int x, int y, int width, int height, int startAngle, int arc
             Cairo.cairo_translate(cairo, x + width / 2f, y + height / 2f);
             Cairo.cairo_scale(cairo, width / 2f, height / 2f);
             if (arcAngle >= 0) {
-                Cairo.cairo_arc_negative(cairo, 0, 0, 1, -startAngle * cast(float)Compatibility.PI / 180,  -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc_negative(cairo, 0, 0, 1, -startAngle * cast(float)Math.PI / 180,  -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             } else {
-                Cairo.cairo_arc(cairo, 0, 0, 1, -startAngle * cast(float)Compatibility.PI / 180,  -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+                Cairo.cairo_arc(cairo, 0, 0, 1, -startAngle * cast(float)Math.PI / 180,  -(startAngle + arcAngle) * cast(float)Math.PI / 180);
             }
             Cairo.cairo_line_to(cairo, 0, 0);
             Cairo.cairo_restore(cairo);
@@ -1902,12 +1901,12 @@ public void fillOval(int x, int y, int width, int height) {
     auto cairo = data.cairo;
     if (cairo !is null) {
         if (width is height) {
-            Cairo.cairo_arc_negative(cairo, x + width / 2f, y + height / 2f, width / 2f, 0, 2 * cast(float)Compatibility.PI);
+            Cairo.cairo_arc_negative(cairo, x + width / 2f, y + height / 2f, width / 2f, 0, 2 * cast(float)Math.PI);
         } else {
             Cairo.cairo_save(cairo);
             Cairo.cairo_translate(cairo, x + width / 2f, y + height / 2f);
             Cairo.cairo_scale(cairo, width / 2f, height / 2f);
-            Cairo.cairo_arc_negative(cairo, 0, 0, 1, 0, 2 * cast(float)Compatibility.PI);
+            Cairo.cairo_arc_negative(cairo, 0, 0, 1, 0, 2 * cast(float)Math.PI);
             Cairo.cairo_restore(cairo);
         }
         Cairo.cairo_fill(cairo);
@@ -2088,10 +2087,10 @@ public void fillRoundRectangle(int x, int y, int width, int height, int arcWidth
             Cairo.cairo_translate(cairo, nx, ny);
             Cairo.cairo_scale(cairo, naw2, nah2);
             Cairo.cairo_move_to(cairo, fw - 1, 0);
-            Cairo.cairo_arc(cairo, fw - 1, 1, 1, Compatibility.PI + Compatibility.PI/2.0, Compatibility.PI*2.0);
-            Cairo.cairo_arc(cairo, fw - 1, fh - 1, 1, 0, Compatibility.PI/2.0);
-            Cairo.cairo_arc(cairo, 1, fh - 1, 1, Compatibility.PI/2, Compatibility.PI);
-            Cairo.cairo_arc(cairo, 1, 1, 1, Compatibility.PI, 270.0*Compatibility.PI/180.0);
+            Cairo.cairo_arc(cairo, fw - 1, 1, 1, Math.PI + Math.PI/2.0, Math.PI*2.0);
+            Cairo.cairo_arc(cairo, fw - 1, fh - 1, 1, 0, Math.PI/2.0);
+            Cairo.cairo_arc(cairo, 1, fh - 1, 1, Math.PI/2, Math.PI);
+            Cairo.cairo_arc(cairo, 1, 1, 1, Math.PI, 270.0*Math.PI/180.0);
             Cairo.cairo_close_path(cairo);
             Cairo.cairo_restore(cairo);
         }
@@ -4023,5 +4022,3 @@ public override String toString () {
 }
 
 }
-
-

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/ImageLoader.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/ImageLoader.d
@@ -13,6 +13,8 @@
 module org.eclipse.swt.graphics.ImageLoader;
 
 import java.lang.all;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.util.Vector;
 
 
@@ -21,7 +23,6 @@ public import org.eclipse.swt.graphics.ImageLoaderEvent;
 public import org.eclipse.swt.graphics.ImageData;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.internal.Compatibility;
 import org.eclipse.swt.internal.image.FileFormat;
 
 version(Tango){
@@ -174,7 +175,7 @@ public ImageData[] load(String filename) {
         }
     }
     try {
-        stream = Compatibility.newFileInputStream(filename);
+        stream = new FileInputStream(filename);
         scope(exit) close();
 
         return load(stream);
@@ -253,7 +254,7 @@ public void save(String filename, int format) {
     if (filename is null) SWT.error(SWT.ERROR_NULL_ARGUMENT);
     OutputStream stream = null;
     try {
-        stream = Compatibility.newFileOutputStream(filename);
+        stream = new FileOutputStream(filename);
     } catch (IOException e) {
         SWT.error(SWT.ERROR_IO, e);
     }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Path.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Path.d
@@ -13,7 +13,6 @@
 module org.eclipse.swt.graphics.Path;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.internal.Compatibility;
 import org.eclipse.swt.internal.cairo.Cairo : Cairo;
 import org.eclipse.swt.internal.gtk.OS;
 import org.eclipse.swt.graphics.Resource;
@@ -48,7 +47,7 @@ version(Tango){
  * @see <a href="http://www.eclipse.org/swt/snippets/#path">Path, Pattern snippets</a>
  * @see <a href="http://www.eclipse.org/swt/examples.php">SWT Example: GraphicsExample</a>
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
- * 
+ *
  * @since 3.1
  */
 public class Path : Resource {
@@ -111,11 +110,11 @@ public this (Device device) {
  * graphics subsystem which may not be available on some
  * platforms.
  * </p>
- * 
+ *
  * @param device the device on which to allocate the path
  * @param path the path to make a copy
  * @param flatness the flatness value
- * 
+ *
  * @exception IllegalArgumentException <ul>
  *    <li>ERROR_NULL_ARGUMENT - if the device is null and there is no current device</li>
  *    <li>ERROR_NULL_ARGUMENT - if the path is null</li>
@@ -127,7 +126,7 @@ public this (Device device) {
  * @exception SWTError <ul>
  *    <li>ERROR_NO_HANDLES if a handle for the path could not be obtained</li>
  * </ul>
- * 
+ *
  * @see #dispose()
  * @since 3.4
  */
@@ -166,10 +165,10 @@ public this (Device device, Path path, float flatness) {
  * graphics subsystem which may not be available on some
  * platforms.
  * </p>
- * 
+ *
  * @param device the device on which to allocate the path
  * @param data the data for the path
- * 
+ *
  * @exception IllegalArgumentException <ul>
  *    <li>ERROR_NULL_ARGUMENT - if the device is null and there is no current device</li>
  *    <li>ERROR_NULL_ARGUMENT - if the data is null</li>
@@ -180,7 +179,7 @@ public this (Device device, Path path, float flatness) {
  * @exception SWTError <ul>
  *    <li>ERROR_NO_HANDLES if a handle for the path could not be obtained</li>
  * </ul>
- * 
+ *
  * @see #dispose()
  * @since 3.4
  */
@@ -223,23 +222,23 @@ public void addArc(float x, float y, float width, float height, float startAngle
     if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
     moved = true;
     if (width is height) {
-        float angle = -startAngle * cast(float)Compatibility.PI / 180;
+        float angle = -startAngle * cast(float)Math.PI / 180;
         if (closed) Cairo.cairo_move_to(handle, (x + width / 2f) + width / 2f * Math.cos(angle), (y + height / 2f) + height / 2f * Math.sin(angle));
         if (arcAngle >= 0) {
-            Cairo.cairo_arc_negative(handle, x + width / 2f, y + height / 2f, width / 2f, angle, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+            Cairo.cairo_arc_negative(handle, x + width / 2f, y + height / 2f, width / 2f, angle, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
         } else {
-            Cairo.cairo_arc(handle, x + width / 2f, y + height / 2f, width / 2f, angle, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+            Cairo.cairo_arc(handle, x + width / 2f, y + height / 2f, width / 2f, angle, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
         }
     } else {
         Cairo.cairo_save(handle);
         Cairo.cairo_translate(handle, x + width / 2f, y + height / 2f);
         Cairo.cairo_scale(handle, width / 2f, height / 2f);
-        float angle = -startAngle * cast(float)Compatibility.PI / 180;
+        float angle = -startAngle * cast(float)Math.PI / 180;
         if (closed) Cairo.cairo_move_to(handle, Math.cos(angle), Math.sin(angle));
         if (arcAngle >= 0) {
-            Cairo.cairo_arc_negative(handle, 0, 0, 1, angle, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+            Cairo.cairo_arc_negative(handle, 0, 0, 1, angle, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
         } else {
-            Cairo.cairo_arc(handle, 0, 0, 1, angle, -(startAngle + arcAngle) * cast(float)Compatibility.PI / 180);
+            Cairo.cairo_arc(handle, 0, 0, 1, angle, -(startAngle + arcAngle) * cast(float)Math.PI / 180);
         }
         Cairo.cairo_restore(handle);
     }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Transform.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Transform.d
@@ -15,7 +15,6 @@ module org.eclipse.swt.graphics.Transform;
 import java.lang.all;
 
 import org.eclipse.swt.SWT;
-import org.eclipse.swt.internal.Compatibility;
 import org.eclipse.swt.internal.cairo.Cairo;
 import org.eclipse.swt.graphics.Resource;
 import org.eclipse.swt.graphics.Device;
@@ -36,7 +35,7 @@ import org.eclipse.swt.graphics.Device;
  *
  * @see <a href="http://www.eclipse.org/swt/examples.php">SWT Example: GraphicsExample</a>
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
- * 
+ *
  * @since 3.1
  */
 public class Transform : Resource {
@@ -184,12 +183,12 @@ public void getElements(float[] elements) {
 
 /**
  * Modifies the receiver such that the matrix it represents becomes the
- * identity matrix. 
+ * identity matrix.
  *
  * @exception SWTException <ul>
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>
  * </ul>
- * 
+ *
  * @since 3.4
  */
 public void identity() {
@@ -277,7 +276,7 @@ public void multiply(Transform matrix) {
  */
 public void rotate(float angle) {
     if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
-    Cairo.cairo_matrix_rotate(cast(cairo_matrix_t*)handle.ptr, angle * cast(float)Compatibility.PI / 180);
+    Cairo.cairo_matrix_rotate(cast(cairo_matrix_t*)handle.ptr, angle * cast(float)Math.PI / 180);
 }
 
 /**
@@ -319,14 +318,14 @@ public void setElements(float m11, float m12, float m21, float m22, float dx, fl
 /**
  * Modifies the receiver so that it represents a transformation that is
  * equivalent to its previous transformation sheared by (shearX, shearY).
- * 
+ *
  * @param shearX the shear factor in the X direction
  * @param shearY the shear factor in the Y direction
- * 
+ *
  * @exception SWTException <ul>
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>
  * </ul>
- * 
+ *
  * @since 3.4
  */
 public void shear(float shearX, float shearY) {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/image/PNGFileFormat.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/image/PNGFileFormat.d
@@ -32,6 +32,7 @@ import org.eclipse.swt.internal.image.PngDecodingDataStream;
 import java.lang.all;
 
 import java.io.BufferedInputStream;
+import java.util.zip.InflaterInputStream;
 
 final class PNGFileFormat : FileFormat {
     static const int SIGNATURE_LENGTH = 8;
@@ -174,7 +175,7 @@ override bool isFileFormat(LEDataInputStream stream) {
         if ((signature[4] & 0xFF) !is 13) return false; //<RETURN>
         if ((signature[5] & 0xFF) !is 10) return false; //<LINEFEED>
         if ((signature[6] & 0xFF) !is 26) return false; //<CTRL/Z>
-        if ((signature[7] & 0xFF) !is 10) return false; //<LINEFEED>     
+        if ((signature[7] & 0xFF) !is 10) return false; //<LINEFEED>
         return true;
     } catch (Exception e) {
         return false;
@@ -311,7 +312,7 @@ void readPixelData(PngIdatChunk chunk, PngChunkReader chunkReader)  {
     //TEMPORARY CODE
     //PORTING_FIXME
     bool use3_2 = true;//System.getProperty("org.eclipse.swt.internal.image.PNGFileFormat_3.2") !is null;
-    InputStream inflaterStream = use3_2 ? null : Compatibility.newInflaterInputStream(stream);
+    InputStream inflaterStream = use3_2 ? null : new InflaterInputStream(stream);
     if (inflaterStream !is null) {
         stream = inflaterStream;
     } else {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/image/PngEncoder.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/internal/image/PngEncoder.d
@@ -18,11 +18,11 @@ import org.eclipse.swt.internal.image.LEDataOutputStream;
 import org.eclipse.swt.internal.image.PngDeflater;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.util.zip.DeflaterOutputStream;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.graphics.ImageData;
 import org.eclipse.swt.graphics.ImageLoader;
 import org.eclipse.swt.graphics.RGB;
-import org.eclipse.swt.internal.Compatibility;
 import org.eclipse.swt.internal.image.PngChunk;
 
 final class PngEncoder {
@@ -238,7 +238,7 @@ void writeTransparency() {
 void writeImageData() {
 
     ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
-    OutputStream os = Compatibility.newDeflaterOutputStream(baos);
+    OutputStream os = new DeflaterOutputStream(baos);
     if (os is null) os = baos;
 
     if (colorType is 3) {


### PR DESCRIPTION
These methods were deprecated by changes in the Compatibility class (commit 14f801a).  Only one not updated is in Synchronizer.d, which would throw an "Implementation Missing" exception because Thread.interrupt hasn't been implemented.

I would like to send a separate pull request to implement the interrupt method, but I'm not completely sure how to. 