### PR TITLE
[unittest] Fix Platform imports

### DIFF
--- a/tests/Platform.d
+++ b/tests/Platform.d
@@ -13,7 +13,8 @@
  *******************************************************************************/
 module tests.Platform;
 
-import java.lang.util.HashSet;
+import java.lang.all;
+import java.util.HashSet;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.program.Program;


### PR DESCRIPTION
I came across an error I made when moving the Platform unit tests to the separate file.  I'm sorry, but here's a fix.