### PR TITLE
[base] Fix SafeUtf unittests

### DIFF
--- a/base/src/java/nonstandard/SafeUtf.d
+++ b/base/src/java/nonstandard/SafeUtf.d
@@ -1,7 +1,7 @@
-/** 
+/**
  * Stuff for working with narrow strings.
  * Safe because of strong type checking.
- * 
+ *
  * Authors: Denis Shelomovskij <verylonglogin.reg@gmail.com>
  */
 module java.nonstandard.SafeUtf;
@@ -19,52 +19,53 @@ unittest {
     auto wstarts  = [1, 1, 1,   1,   1,     1,     1,0,     1,0    , 1];
     assert(s.length == starts.length);
     assert(ws.length == wstarts.length);
-    
+
     auto  strides = [1, 1, 2, 2, 3, 3, 4, 4, 1];
     auto wstrides = [1, 1, 1, 1, 1, 1, 2, 2, 1];
     auto shifts0 = [0, 1, 1+1, 1+1+2, 1+1+2+2, 1+1+2+2+3, 1+1+2+2+3+3, 1+1+2+2+3+3+4, 1+1+2+2+3+3+4+4];
     assert(strides.length == dchars.length);
     assert(wstrides.length == dchars.length);
     assert(shifts0.length == dchars.length);
-    
+
     UTF8index prevStart = 0;
     UCSindex n = 0;
-    foreach(UTF8index i, char ch; s) {
-        assert(s.isUTF8sequenceStart(i) == starts[i]);
-        if(starts[i]) {
-            s.validateUTF8index(i);
-            assert(s.UTF8strideAt(i) == strides[n]);
-            assert(s.toUTF8shift(0, n) == shifts0[n]);
-            assert(s.toUTF8shift(shifts0[n], -n) == -shifts0[n]);
-            if(i) assert(s.offsetBefore(i) == prevStart);
-            assert(s[0 .. val(i)].UCScount == n);
-            assert(s[val(i) .. $].UCScount == strides.length - n);
-            
+    foreach(size_t iter, char ch; s) {
+        UTF8index idx = iter;
+        assert(s.isUTF8sequenceStart(idx) == starts[iter]);
+        if (starts[iter]) {
+            s.validateUTF8index(idx);
+            assert(s.UTF8strideAt(idx) == strides[n]);
+            assert(s.toUTF8shift(UTF8index(0), n) == shifts0[n]);
+            assert(s.toUTF8shift( UTF8index(shifts0[n]), -n) == -shifts0[n]);
+            if (iter) assert(s.offsetBefore(idx) == prevStart);
+            assert(s[0 .. val(idx)].UCScount == n);
+            assert(s[val(idx) .. $].UCScount == strides.length - n);
+
             UTF8shift di;
-            assert(s.dcharAt(i, di) == dchars[n]);
+            assert(s.dcharAt(idx, di) == dchars[n]);
             assert(di == strides[n]);
-            if(i) assert(s.dcharBefore(i) == s.dcharAt(prevStart));
-            if(i) assert(s.dcharAfter(prevStart) == s.dcharAt(i));
-            auto dcharStr = s[val(i) .. val(i) + strides[n]];
-            assert(s.dcharAsStringAt(i, di) == dcharStr && di == dcharStr.length);
-            assert(dcharToString(s.dcharAt(i)) == dcharStr);
-            prevStart = i;
+            if (iter) assert(s.dcharBefore(idx) == s.dcharAt(prevStart));
+            if (iter) assert(s.dcharAfter(prevStart) == s.dcharAt(idx));
+            auto dcharStr = s[val(idx) .. val(idx) + strides[n]];
+            assert(s.dcharAsStringAt(idx, di) == dcharStr && di == dcharStr.length);
+            assert(dcharToString(s.dcharAt(idx)) == dcharStr);
+            prevStart = idx;
             ++n;
         }
-        UTF8index t = i;
+        UTF8index t = idx;
         s.adjustUTF8index(t);
         assert(t == prevStart);
     }
-    
+
     n = 0;
     foreach(UTF16index i, wchar ch; ws)
-        if(wstarts[i]) {
+        if (wstarts[i]) {
             //s.validateUTF16index(i);
             UTF16shift di;
             assert(ws.dcharAt(i, di) == dchars[n]);
             assert(di == wstrides[n]);
             ++n;
         }
-    
-    s.validateUTF8index(s.length);
+
+    s.validateUTF8index( UTF8index(cast(ptrdiff_t)s.length) );
 }

--- a/base/src/java/nonstandard/UtfBase.d
+++ b/base/src/java/nonstandard/UtfBase.d
@@ -1,8 +1,8 @@
-/** 
+/**
  * Stuff for working with narrow strings.
  * This module shouldn't be imported directly.
  * Use SafeUtf/UnsafeUtf modules instead.
- * 
+ *
  * Authors: Denis Shelomovskij <verylonglogin.reg@gmail.com>
  */
 module java.nonstandard.UtfBase;
@@ -27,39 +27,39 @@ static if(UTFTypeCheck) {
     /*struct UTF16index {
         ptrdiff_t internalValue;
         alias internalValue val;
-        
+
         private static UTF16index opCall(ptrdiff_t _val) {
             UTF16index t = { _val };
             return t;
         }
-        
+
         void opOpAssign(string op)(in UTF16shift di) if (op == "+") {
             val += di;
         }
-        
+
         void opOpAssign(string op)(in UTF16shift di) if (op == "-") {
             val -= di;
         }
-        
+
 mixin(constFuncs!("
         UTF16index opBinary(string op)(in UTF16shift di) if (op == \"+\") {
             return UTF16index(val + di);
         }
-        
+
         UTF16index opBinary(string op)(in UTF16shift di) if (op == \"-\") {
             return UTF16index(val - di);
         }
-        
+
         version(Windows) {
             UTF16index opBinary(string op)(in ptrdiff_t di) if (op == \"+\") {
                 return UTF16index(val + di);
             }
-            
+
             UTF16index opBinary(string op)(in ptrdiff_t di) if (op == \"-\") {
                 return UTF16index(val - di);
             }
         }
-        
+
         int opCmp(in UTF16index i2) {
             return cast(int)(val - i2.val);
         }
@@ -74,86 +74,92 @@ mixin(constFuncs!("
     struct UTF8index {
         ptrdiff_t internalValue;
         alias internalValue val;
-        
+
         private static UTF8index opCall(ptrdiff_t _val) {
             UTF8index t = { _val };
             return t;
         }
-        
+
         void opOpAssign(string op)(in UTF8shift di) if (op == "+") {
             val += di.val;
         }
-        
+
         void opOpAssign(string op)(in UTF8shift di) if (op == "-") {
             val -= di.val;
         }
-        
+
 mixin(constFuncs!("
         UTF8index opBinary(string op)(in UTF8shift di) if (op == \"+\") {
             return UTF8index(val + di.val);
         }
-        
+
         UTF8index opBinary(string op)(in UTF8shift di) if (op == \"-\") {
             return UTF8index(val - di.val);
         }
-        
+
         UTF8shift opBinary(string op)(in UTF8index di) if (op == \"-\") {
             return UTF8shift(val - di.val);
         }
-        
+
         int opCmp(in UTF8index i2) {
             return cast(int)(val - i2.val);
         }
 "));
     }
-    
+
     private UTF8index newUTF8index(ptrdiff_t i) {
         return UTF8index(i);
     }
-    
+
     private ptrdiff_t val(T)(T i) {
         static if(is(T : UTF16index))
             return cast(ptrdiff_t) i;
         else
             return i.val;
     }
-    
+
     private void dec(ref UTF8index i) {
         --i.val;
     }
-    
+
     struct UTF8shift {
         ptrdiff_t internalValue;
         alias internalValue val;
-        
+
         private static UTF8shift opCall(ptrdiff_t _val) {
             UTF8shift t = { _val };
             return t;
         }
-        
+
         void opOpAssign(string op)(in UTF8shift di) if (op == "+") {
             val += di.val;
         }
-        
+
         void opOpAssign(string op)(in UTF8shift di) if (op == "-") {
             val -= di.val;
         }
-        
+
+        bool opEquals(T)(in T s)
+        if (__traits(isArithmetic, s))
+        {
+            return val == s;
+        }
+
 mixin(constFuncs!("
         UTF8shift opBinary(string op)(in UTF8shift di) if (op == \"+\") {
             return UTF8shift(val + di.val);
         }
-        
+
         UTF8shift opBinary(string op)(in UTF8shift di) if (op == \"-\") {
             return UTF8shift(val - di.val);
         }
-        
+
         int opCmp(in UTF8shift di2) {
             return cast(int)(val - di2.val);
         }
 "));
     }
-    
+
 
     UTF8index asUTF8index(ptrdiff_t i) {
         return UTF8index(i);
@@ -165,14 +171,14 @@ mixin(constFuncs!("
 } else {
     alias ptrdiff_t UTF16index;
     alias ptrdiff_t UTF16shift;
-    
+
     alias ptrdiff_t UTF8index;
     alias ptrdiff_t UTF8shift;
-    
+
     private ptrdiff_t val(ptrdiff_t i) {
         return i;
     }
-    
+
     private void dec(ref UTF8index i) {
         --i;
     }
@@ -331,7 +337,7 @@ will return the position of the first byte of this sequence.
 void adjustUTF8index( in char[] s, ref UTF8index i ){
     if(i == s.endIndex() || s.isUTF8sequenceStart(i))
         return;
-    
+
     int l = 0;
     alias i res;
     do {


### PR DESCRIPTION
Fixes the SafeUtf unittests.

As I wrote in the commit message, an `opEquals` overload was added to the `UTF8shift` struct and a separation between the `foreach` iterator and the actual `UTF8index` was made.