### PR TITLE
[Gtk] Add RGBA class

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/RGBA.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/RGBA.d
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D Programming Language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.graphics.RGBA;
+
+import java.lang.all;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
+
+/**
+ * Instances of this class are descriptions of colors in
+ * terms of the primary additive color model (red, green, blue
+ * and alpha). A color may be described in terms of the relative
+ * intensities of these three primary colors. The brightness
+ * of each color is specified by a value in the range 0 to 255,
+ * where 0 indicates no color (blackness) and 255 indicates
+ * maximum intensity and for alpha 0 indicates transparent and
+ * 255 indicates opaque.
+ * <p>
+ * The hashCode() method in this class uses the values of the public
+ * fields to compute the hash value. When storing instances of the
+ * class in hashed collections, do not modify these fields after the
+ * object has been inserted.
+ * </p>
+ * <p>
+ * Application code does <em>not</em> need to explicitly release the
+ * resources managed by each instance when those instances are no longer
+ * required, and thus no <code>dispose()</code> method is provided.
+ * </p>
+ *
+ * @see Color
+ * @see <a href="http://www.eclipse.org/swt/snippets/#color">Color and RGB snippets</a>
+ * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
+ * @since 3.104
+ */
+public final class RGBA {
+  package:
+
+    /**
+     * the RGB component of the RGBA
+     */
+    public const RGB rgb;
+
+    /**
+     * the alpha component of the RGBA
+     */
+    public int alpha;
+
+    // static const long serialVersionUID = 1049467103126495855L;
+
+/**
+ * Constructs an instance of this class with the given
+ * red, green, blue and alpha values.
+ *
+ * @param red the red component of the new instance
+ * @param green the green component of the new instance
+ * @param blue the blue component of the new instance
+ * @param alpha the alpha component of the new instance
+ *
+ * @exception IllegalArgumentException <ul>
+ *    <li>ERROR_INVALID_ARGUMENT - if the red, green, blue or alpha argument is not between 0 and 255</li>
+ * </ul>
+ */
+public this(int red, int green, int blue, int alpha) {
+    if ((alpha > 255) || (alpha < 0)) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+    this.rgb = new RGB (red, green, blue);
+    this.alpha = alpha;
+}
+
+/**
+* Constructs an instance of this class with the given
+* hue, saturation, and brightness.
+*
+* @param hue the hue value for the HSBA color (from 0 to 360)
+* @param saturation the saturation value for the HSBA color (from 0 to 1)
+* @param brightness the brightness value for the HSBA color (from 0 to 1)
+* @param alpha the alpha value for the HSBA color (from 0 to 255)
+*
+* @exception IllegalArgumentException <ul>
+*    <li>ERROR_INVALID_ARGUMENT - if the hue is not between 0 and 360 or
+*    the saturation or brightness is not between 0 and 1 or if the alpha
+*    is not between 0 and 255</li>
+* </ul>
+*
+*/
+public this(float hue, float saturation, float brightness, float alpha) {
+    if ((alpha > 255) || (alpha < 0)) SWT.error(SWT.ERROR_INVALID_ARGUMENT);
+    rgb = new RGB(hue, saturation, brightness);
+    this.alpha = cast(int)(alpha + 0.5);
+}
+
+/**
+ * Returns the hue, saturation, and brightness of the color.
+ *
+ * @return color space values in float format:<ul>
+ *             <li>hue (from 0 to 360)</li>
+ *             <li>saturation (from 0 to 1)</li>
+ *             <li>brightness (from 0 to 1)</li>
+ *             <li>alpha (from 0 to 255)</li>
+ *             </ul>
+ * @see #RGBA(float, float, float, float)
+ */
+public float[] getHSBA() const {
+    float[] hsb = rgb.getHSB();
+    return [hsb[0], hsb[1], hsb[2], alpha];
+}
+
+/**
+ * Compares the argument to the receiver, and returns true
+ * if they represent the <em>same</em> object using a class
+ * specific comparison.
+ *
+ * @param object the object to compare with this object
+ * @return <code>true</code> if the object is the same as this object and <code>false</code> otherwise
+ *
+ * @see #hashCode()
+ */
+override
+public bool opEquals(Object other) const {
+    if (other is this) return true;
+    if (!(cast(RGBA)other)) return false;
+    RGBA rgba = cast(RGBA)other;
+    return (rgba.rgb.red == this.rgb.red) && (rgba.rgb.green == this.rgb.green) && (rgba.rgb.blue == this.rgb.blue) &&
+        (rgba.alpha == this.alpha);
+}
+
+/**
+ * Returns an integer hash code for the receiver. Any two
+ * objects that return <code>true</code> when passed to
+ * <code>equals</code> must return the same value for this
+ * method.
+ *
+ * @return the receiver's hash
+ *
+ * @see #equals(Object)
+ */
+override
+public size_t toHash() const @safe pure nothrow {
+    return (alpha << 24) | (rgb.blue << 16) | (rgb.green << 8) | rgb.red;
+}
+
+/**
+ * Returns a string containing a concise, human-readable
+ * description of the receiver.
+ *
+ * @return a string representation of the <code>RGBA</code>
+ */
+override
+public String toString() const {
+    return Format("RGBA {{{}, {}, {}, {}}", rgb.red, rgb.green, rgb.blue, alpha);
+}
+}

--- a/tests/RGBA.d
+++ b/tests/RGBA.d
@@ -1,0 +1,386 @@
+/*******************************************************************************
+ * Copyright (c) 2015, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc. - Bug 462631
+ * Port to the D Programming Language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module tests.RGBA;
+
+import std.exception : assertThrown;
+
+import java.lang.exceptions;
+import java.lang.String;
+
+import org.eclipse.swt.graphics.RGBA;
+
+/*
+ * Automated Test Suite for class org.eclipse.swt.graphics.RGBA
+ */
+
+@("test_ConstructorIIII")
+unittest
+{
+    // Test RGBA(int red, int green, int blue, int alpha)
+    new RGBA(20, 100, 200, 255);
+
+    new RGBA(0, 0, 0, 0);
+
+    assertThrown!IllegalArgumentException(new RGBA(-1, 20, 50, 255),
+        "No exception thrown for red < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(256, 20, 50, 255),
+        "No exception thrown for red > 255");
+
+    assertThrown!IllegalArgumentException(new RGBA(20, -1, 50, 0),
+        "No exception thrown for green < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(20, 256, 50, 0),
+        "No exception thrown for green > 255");
+
+    assertThrown!IllegalArgumentException(new RGBA(20, 50, -1, 0),
+        "No exception thrown for blue < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(20, 50, 256, 0),
+        "No exception thrown for blue > 255");
+
+    assertThrown!IllegalArgumentException(new RGBA(20, 50, 10, -1),
+        "No exception thrown for alpha < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(20, 50, 10, 256),
+        "No exception thrown for alpha > 255");
+}
+
+@("test_ConstructorFFFF")
+unittest
+{
+    new RGBA(0f,0f,0f,0f);
+
+    new RGBA(0f,1f,0f,0f);
+    new RGBA(0f,0f,1f,1f);
+    new RGBA(0f,0.6f,0.4f,0.8f);
+    new RGBA(1f,0f,1f,1f);
+    new RGBA(1f,1f,1f,1f);
+    new RGBA(1f,0f,1f,0f);
+    new RGBA(1f,1f,0f,1f);
+    new RGBA(1f,0.6f,0.4f,0.8f);
+    new RGBA(59f,0f,1f,1f);
+    new RGBA(59f,1f,1f,1f);
+    new RGBA(59f,0f,1f,1f);
+    new RGBA(59f,1f,0f,1f);
+    new RGBA(59f,0.6f,0.4f,0.8f);
+    new RGBA(60f,0f,1f,1f);
+    new RGBA(60f,1f,1f,1f);
+    new RGBA(60f,0f,1f,1f);
+    new RGBA(60f,1f,0f,1f);
+    new RGBA(60f,0.6f,0.4f,0.8f);
+    new RGBA(61f,0f,1f,1f);
+    new RGBA(61f,1f,1f,1f);
+    new RGBA(61f,0f,1f,1f);
+    new RGBA(61f,1f,0f,1f);
+    new RGBA(61f,0.6f,0.4f,0.8f);
+    new RGBA(119f,0f,1f,1f);
+    new RGBA(119f,1f,1f,1f);
+    new RGBA(119f,0f,1f,1f);
+    new RGBA(119f,1f,0f,0f);
+    new RGBA(119f,0.6f,0.4f,0.8f);
+    new RGBA(120f,0f,1f,1f);
+    new RGBA(120f,1f,1f,1f);
+    new RGBA(120f,0f,1f,1f);
+    new RGBA(120f,1f,0f,0f);
+    new RGBA(120f,0.6f,0.4f,0.8f);
+    new RGBA(121f,0f,1f,1f);
+    new RGBA(121f,1f,1f,1f);
+    new RGBA(121f,0f,1f,1f);
+    new RGBA(121f,1f,0f,0f);
+    new RGBA(121f,0.6f,0.4f,0.8f);
+    new RGBA(179f,0f,1f,1f);
+    new RGBA(179f,1f,1f,1f);
+    new RGBA(179f,0f,1f,1f);
+    new RGBA(179f,1f,0f,0f);
+    new RGBA(179f,0.6f,0.4f,0.8f);
+    new RGBA(180f,0f,1f,1f);
+    new RGBA(180f,1f,1f,1f);
+    new RGBA(180f,0f,1f,1f);
+    new RGBA(180f,1f,0f,0f);
+    new RGBA(180f,0.6f,0.4f,0.8f);
+    new RGBA(181f,0f,1f,1f);
+    new RGBA(181f,1f,1f,1f);
+    new RGBA(181f,0f,1f,1f);
+    new RGBA(181f,1f,0f,0f);
+    new RGBA(181f,0.6f,0.4f,0.8f);
+    new RGBA(239f,0f,1f,1f);
+    new RGBA(239f,1f,1f,1f);
+    new RGBA(239f,0f,1f,1f);
+    new RGBA(239f,1f,0f,0f);
+    new RGBA(239f,0.6f,0.4f,0.8f);
+    new RGBA(240f,0f,1f,1f);
+    new RGBA(240f,1f,1f,1f);
+    new RGBA(240f,0f,1f,1f);
+    new RGBA(240f,1f,0f,0f);
+    new RGBA(240f,0.6f,0.4f,0.8f);
+    new RGBA(241f,0f,1f,1f);
+    new RGBA(241f,1f,1f,1f);
+    new RGBA(241f,0f,1f,1f);
+    new RGBA(241f,1f,0f,0f);
+    new RGBA(241f,0.6f,0.4f,0.8f);
+    new RGBA(299f,0f,1f,1f);
+    new RGBA(299f,1f,1f,1f);
+    new RGBA(299f,0f,1f,1f);
+    new RGBA(299f,1f,0f,0f);
+    new RGBA(299f,0.6f,0.4f,0.8f);
+    new RGBA(300f,0f,1f,1f);
+    new RGBA(300f,1f,1f,1f);
+    new RGBA(300f,0f,1f,1f);
+    new RGBA(300f,1f,0f,0f);
+    new RGBA(300f,0.6f,0.4f,0.8f);
+    new RGBA(301f,0f,1f,1f);
+    new RGBA(301f,1f,1f,1f);
+    new RGBA(301f,0f,1f,1f);
+    new RGBA(301f,1f,0f,0f);
+    new RGBA(301f,0.6f,0.4f,0.8f);
+    new RGBA(359f,0f,1f,1f);
+    new RGBA(359f,1f,1f,1f);
+    new RGBA(359f,0f,1f,1f);
+    new RGBA(359f,1f,0f,0f);
+    new RGBA(359f,0.6f,0.4f,0.8f);
+    new RGBA(360f,0f,1f,1f);
+    new RGBA(360f,1f,1f,1f);
+    new RGBA(360f,0f,1f,1f);
+    new RGBA(360f,1f,0f,0f);
+    new RGBA(360f,0.6f,0.4f,0.8f);
+
+    assertThrown!IllegalArgumentException(new RGBA(400f, 0.5f, 0.5f, 0.8f),
+        "No exception thrown for hue > 360");
+
+    assertThrown!IllegalArgumentException(new RGBA(-5f, 0.5f, 0.5f, 0.8f),
+        "No exception thrown for hue < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(200f, -0.5f, 0.5f, 0.8f),
+        "No exception thrown for saturation < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(200f, 300f, 0.5f, 0.8f),
+        "No exception thrown for saturation > 1");
+
+    assertThrown!IllegalArgumentException(new RGBA(200f, 0.5f, -0.5, 0.8f),
+        "No exception thrown for brightness < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(200f, 0.5f, 400f, 0.8f),
+        "No exception thrown for brightness > 1");
+
+    assertThrown!IllegalArgumentException(new RGBA(200f, 0.5f, 0.5f, -0.5f),
+        "No exception thrown for alpha < 0");
+
+    assertThrown!IllegalArgumentException(new RGBA(200f, 0.5f, 0.5f, 400f),
+        "No exception thrown for alpha > 1");
+}
+
+@("test_equalsLjava_lang_Object")
+unittest
+{
+    int r = 0, g = 127, b = 254, a = 254;
+    RGBA rgba1 = new RGBA(r, g, b, a);
+    RGBA rgba2;
+
+    rgba2 = rgba1;
+    if (rgba1 != rgba2) {
+        assert(false, "Two references to the same RGBA instance not found equal");
+    }
+
+    rgba2 = new RGBA(r, g, b, a);
+    if (rgba1 != rgba2) {
+        assert(false, "References to two different RGBA instances with same R G B A parameters not found equal");
+    }
+
+    if (rgba1 == (new RGBA(r+1, g, b, a)) ||
+        rgba1 == (new RGBA(r, g+1, b, a)) ||
+        rgba1 == (new RGBA(r, g, b+1, a)) ||
+        rgba1 == (new RGBA(r, g, b, a+1)) ||
+        rgba1 == (new RGBA(r+1, g+1, b+1, a+1))) {
+            assert(false, "Comparing two RGBA instances with different combination of R G B A parameters found equal");
+    }
+
+    float hue = 220f, sat = 0.6f, bright = 0.7f, alpha = 0.5f;
+    rgba1 = new RGBA(hue, sat, bright, alpha);
+    rgba2 = rgba1;
+    if (rgba1 != (rgba2)) {
+        assert(false, "Two references to the same RGBA instance not found equal");
+    }
+
+    rgba2 = new RGBA(hue, sat, bright, alpha);
+    if (rgba1 != (rgba2)) {
+        assert(false, "References to two different RGBA isntances with same H S B A parameters not found equal");
+    }
+
+    if (rgba1 == (new RGBA(hue+1, sat, bright, alpha)) ||
+        rgba1 == (new RGBA(hue, sat+0.1f, bright, alpha)) ||
+        rgba1 == (new RGBA(hue, sat, bright+0.1f, alpha)) ||
+        rgba1 == (new RGBA(hue, sat, bright, alpha+1f)) ||
+        rgba1 == (new RGBA(hue+1, sat+0.1f, bright+0.1f, alpha+1f))) {
+            assert(false, "Comparing two RGBA instances with different combination of H S B A parameters found equal");
+    }
+}
+
+@("test_getHSBA")
+unittest
+{
+    float[] hsba = [
+                0f,0f,0f,0f,
+                0f,1f,1f,1f,
+                0f,1f,0f,0f,
+                0f,0f,1f,1f,
+                0f,0.6f,0.4f,0.8f,
+                1f,0f,1f,1f,
+                1f,1f,1f,1f,
+                1f,0f,1f,1f,
+                1f,1f,0f,0f,
+                1f,0.6f,0.4f,0.8f,
+                59f,0f,1f,1f,
+                59f,1f,1f,1f,
+                59f,0f,1f,1f,
+                59f,1f,0f,0f,
+                59f,0.6f,0.4f,0.8f,
+                60f,0f,1f,1f,
+                60f,1f,1f,1f,
+                60f,0f,1f,1f,
+                60f,1f,0f,0f,
+                60f,0.6f,0.4f,0.8f,
+                61f,0f,1f,1f,
+                61f,1f,1f,1f,
+                61f,0f,1f,1f,
+                61f,1f,0f,0f,
+                61f,0.6f,0.4f,0.8f,
+                119f,0f,1f,1f,
+                119f,1f,1f,1f,
+                119f,0f,1f,1f,
+                119f,1f,0f,0f,
+                119f,0.6f,0.4f,0.8f,
+                120f,0f,1f,1f,
+                120f,1f,1f,1f,
+                120f,0f,1f,1f,
+                120f,1f,0f,0f,
+                120f,0.6f,0.4f,0.8f,
+                121f,0f,1f,1f,
+                121f,1f,1f,1f,
+                121f,0f,1f,1f,
+                121f,1f,0f,0f,
+                121f,0.6f,0.4f,0.8f,
+                179f,0f,1f,1f,
+                179f,1f,1f,1f,
+                179f,0f,1f,1f,
+                179f,1f,0f,0f,
+                179f,0.6f,0.4f,0.8f,
+                180f,0f,1f,1f,
+                180f,1f,1f,1f,
+                180f,0f,1f,1f,
+                180f,1f,0f,0f,
+                180f,0.6f,0.4f,0.8f,
+                181f,0f,1f,1f,
+                181f,1f,1f,1f,
+                181f,0f,1f,1f,
+                181f,1f,0f,0f,
+                181f,0.6f,0.4f,0.8f,
+                239f,0f,1f,1f,
+                239f,1f,1f,1f,
+                239f,0f,1f,1f,
+                239f,1f,0f,0f,
+                239f,0.6f,0.4f,0.8f,
+                240f,0f,1f,1f,
+                240f,1f,1f,1f,
+                240f,0f,1f,1f,
+                240f,1f,0f,0f,
+                240f,0.6f,0.4f,0.8f,
+                241f,0f,1f,1f,
+                241f,1f,1f,1f,
+                241f,0f,1f,1f,
+                241f,1f,0f,0f,
+                241f,0.6f,0.4f,0.8f,
+                299f,0f,1f,1f,
+                299f,1f,1f,1f,
+                299f,0f,1f,1f,
+                299f,1f,0f,0f,
+                299f,0.6f,0.4f,0.8f,
+                300f,0f,1f,1f,
+                300f,1f,1f,1f,
+                300f,0f,1f,1f,
+                300f,1f,0f,0f,
+                300f,0.6f,0.4f,0.8f,
+                301f,0f,1f,1f,
+                301f,1f,1f,1f,
+                301f,0f,1f,1f,
+                301f,1f,0f,0f,
+                301f,0.6f,0.4f,0.8f,
+                359f,0f,1f,1f,
+                359f,1f,1f,1f,
+                359f,0f,1f,1f,
+                359f,1f,0f,0f,
+                359f,0.6f,0.4f,0.8f,
+                360f,0f,1f,1f,
+                360f,1f,1f,1f,
+                360f,0f,1f,1f,
+                360f,1f,0f,0f,
+                360f,0.6f,0.4f,0.8f,
+                220f,0.6f,0.7f,0.8f];
+    for (int i = 0; i < hsba.length; i+=4) {
+        RGBA rgba1 = new RGBA(hsba[i], hsba[i+1], hsba[i+2], hsba[i+3]);
+        float[] hsba2 = rgba1.getHSBA();
+        RGBA rgba2 = new RGBA(hsba2[0], hsba2[1], hsba2[2], hsba2[3]);
+        if (rgba1 != rgba2) {
+            assert(false, "Two references to the same RGBA using getHSBA() function not found equal");
+        }
+    }
+}
+
+@("test_hashCode")
+unittest
+{
+    int r = 255, g = 100, b = 0, a = 0, different = 150;
+    RGBA rgba1 = new RGBA(r, g, b, a);
+    RGBA rgba2 = new RGBA(r, g, b, a);
+
+    size_t hash1 = rgba1.toHash();
+    size_t hash2 = rgba2.toHash();
+
+    if (hash1 != hash2) {
+        assert(false, "Two RGBA instances with same R G B A parameters returned different hash codes");
+    }
+
+    if (rgba1.toHash() == new RGBA(g, b, r, a).toHash() ||
+        rgba1.toHash() == new RGBA(b, r, g, a).toHash()) {
+            assert(false, "Two RGBA instances with different R G B A parameters returned the same hash code");
+    }
+
+    if (rgba1.toHash() == new RGBA(different, g, b, a).toHash()) {
+        assert(false, "Two RGBA instances with different RED parameters returned the same hash code");
+    }
+
+    if (rgba1.toHash() == new RGBA(r, different, b, a).toHash()) {
+        assert(false, "Two RGBA instances with different GREEN parameters returned the same hash code");
+    }
+
+    if (rgba1.toHash() == new RGBA(r, g, different, a).toHash()) {
+        assert(false, "Two RGBA instances with different BLUE parameters returned the same hash code");
+    }
+
+    if (rgba1.toHash() == new RGBA(r, g, b, different).toHash()) {
+        assert(false, "Two RGBA instances with different ALPHA parameters returned the same hash code");
+    }
+}
+
+@("test_toString")
+unittest
+{
+    RGBA rgba = new RGBA(0, 100, 200, 255);
+
+    String s = rgba.toString();
+
+    if (s is null || s.length() == 0) {
+        assert(false, "RGBA.toString returns a null or empty string");
+    }
+}


### PR DESCRIPTION
As you'd expect, it's mostly the same as the `RGB` class, just with the addition of alpha.

After this, I'll work on fixing the current issues preventing the CI from passing the tests.