### PR TITLE
[base] Allow Format to apply format to array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@
 /org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/snippet*
 !org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet*.d
 /args.txt
-dwt-test-*
+dwt-*-test-*


### PR DESCRIPTION
This PR fixes the failing unittest in [java/lang/util.d#L322 ](https://github.com/d-widget-toolkit/dwt/blob/56cc788107b7e8626d8b460fd97078c626e97142/base/src/java/lang/util.d#L332) and makes some adjustments to allow formatting of arrays.

The code is mostly just a copy of the existing `fmtFromTangoFmt` function, with the difference being the changes to support arrays and to allows for a mix between positional and non-positional formatting (e.g. `{} {1} {}`) .

I've marked this as a draft as I haven't removed the `fmtFromTangoFmt` code (and fixed references) since I wanted to see if you had another way to go about this.