### PR TITLE
Update snippets 1 - 10

### DIFF
--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet1.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet1.d
@@ -1,0 +1,65 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet1"
+    dependency "dwt" path="../../../../../../" version="*"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "gio-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+/*******************************************************************************
+ * Copyright (c) 2000, 2012 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * D Port:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.snippets.Snippet1;
+
+/*
+ * example snippet: Hello World
+ *
+ * For a list of all SWT example snippets see
+ * http://www.eclipse.org/swt/snippets/
+ */
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swt.widgets.Shell;
+
+void main(string[] args) {
+    Display display = new Display;
+    Shell shell = new Shell(display);
+    shell.open();
+    while (!shell.isDisposed()) {
+        if (!display.readAndDispatch()) display.sleep();
+    }
+    display.dispose();
+}

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet10.d
@@ -2,7 +2,7 @@
 /+
 dub.sdl:
     name "snippet10"
-    dependency "dwt" path="../../../../../../"
+    dependency "dwt" path="../../../../../../" version="*"
     libs \
       "atk-1.0" \
       "cairo" \
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \
@@ -34,7 +33,7 @@ dub.sdl:
 +/
 
 /*******************************************************************************
- * Copyright (c) 2000, 2005 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -47,12 +46,12 @@ dub.sdl:
  *******************************************************************************/
 module org.eclipse.swt.snippets.Snippet10;
 
-/* 
+/*
  * Draw using transformations, paths and alpha blending
  *
  * For a list of all SWT example snippets see
  * http://www.eclipse.org/swt/snippets/
- * 
+ *
  * @since 3.1
  */
 import org.eclipse.swt.SWT;
@@ -82,7 +81,7 @@ void main() {
     gc.dispose();
     shell.addListener(SWT.Paint, new class Listener {
             public void handleEvent(Event event) {
-                GC gc = event.gc;               
+                GC gc = event.gc;
                 Transform tr = new Transform(display);
                 tr.translate(50, 120);
                 tr.rotate(-30);
@@ -97,7 +96,7 @@ void main() {
                 gc.drawPath(path);
                 tr.dispose();
                 path.dispose();
-            }           
+            }
         });
     shell.setSize(shell.computeSize(rect.width / 2, rect.height / 2));
     shell.open();
@@ -109,4 +108,3 @@ void main() {
     font.dispose();
     display.dispose();
 }
-

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet2.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet2.d
@@ -1,0 +1,118 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet2"
+    dependency "dwt" path="../../../../../../" version="*"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "gio-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * D Port:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.snippets.Snippet2;
+
+import std.algorithm.comparison : cmp;
+
+/*
+ * Table example snippet: sort a table by column
+ *
+ * For a list of all SWT example snippets see
+ * http://www.eclipse.org/swt/snippets/
+ *
+ * @since 3.2
+ */
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.all;
+import org.eclipse.swt.widgets.all;
+
+void main(string[] args) {
+    Display display = new Display();
+    Shell shell = new Shell(display);
+    shell.setLayout(new FillLayout());
+    Table table = new Table(shell, SWT.BORDER);
+    table.setHeaderVisible(true);
+    TableColumn column1 = new TableColumn(table, SWT.NONE);
+    column1.setText("Column 1");
+    TableColumn column2 = new TableColumn(table, SWT.NONE);
+    column2.setText("Column 2");
+    TableItem item = new TableItem(table, SWT.NONE);
+    item.setText(["a", "3"]);
+    item = new TableItem(table, SWT.NONE);
+    item.setText(["b", "2"]);
+    item = new TableItem(table, SWT.NONE);
+    item.setText(["c", "1"]);
+    column1.setWidth(100);
+    column2.setWidth(100);
+
+    SelectionListener sortListener = new class SelectionListener {
+        override void widgetSelected(SelectionEvent e) {
+            TableItem[] items = table.getItems();
+            TableColumn column = cast(TableColumn)e.widget;
+            int index = column is column1 ? 0 : 1;
+            for (int i = 1; i < items.length; i++) {
+                string value1 = items[i].getText(index);
+                for (int j = 0; j < i; j++) {
+                    string value2 = items[j].getText(index);
+                    if (cmp(value1, value2) < 0) {
+                        string[] values = [items[i].getText(0), items[i].getText(1)];
+                        items[i].dispose();
+                        TableItem item1 = new TableItem(table, SWT.NONE, j);
+                        item1.setText(values);
+                        items = table.getItems();
+                        break;
+                    }
+                }
+            }
+            table.setSortColumn(column);
+        }
+
+        override void widgetDefaultSelected(SelectionEvent e) {}
+    };
+
+    column1.addSelectionListener(sortListener);
+    column2.addSelectionListener(sortListener);
+    table.setSortColumn(column1);
+    table.setSortDirection(SWT.UP);
+    shell.setSize(shell.computeSize(SWT.DEFAULT, SWT.DEFAULT).x, 300);
+    shell.open();
+    while (!shell.isDisposed()) {
+        if (!display.readAndDispatch()) display.sleep();
+    }
+    display.dispose();
+}

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet3.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet3.d
@@ -1,0 +1,107 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet3"
+    dependency "dwt" path="../../../../../../" version="*"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "gio-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * D Port:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.snippets.Snippet3;
+
+import std.conv : to;
+import std.stdio : writeln;
+
+/*
+ * Table example snippet: find a table cell from mouse down (SWT.FULL_SELECTION)
+ *
+ * For a list of all SWT example snippets see
+ * http://www.eclipse.org/swt/snippets/
+ */
+import org.eclipse.swt.all;
+import org.eclipse.swt.graphics.all;
+import org.eclipse.swt.widgets.all;
+
+void main(string[] args) {
+    Display display = new Display();
+    Shell shell = new Shell(display);
+    Table table = new Table(shell, SWT.BORDER | SWT.V_SCROLL |
+            SWT.FULL_SELECTION);
+    table.setHeaderVisible(true);
+    table.setLinesVisible(true);
+    const int rowCount = 64, columnCount = 4;
+    for (int i = 0; i < columnCount; i++) {
+        TableColumn column = new TableColumn(table, SWT.NONE);
+        column.setText("Column " ~ to!string(i));
+    }
+    for (int i = 0; i < rowCount; i++) {
+        TableItem item = new TableItem(table, SWT.NONE);
+        for (int j = 0; j < columnCount; j++) {
+            item.setText(j, "Item " ~ to!string(i) ~ "-" ~ to!string(j));
+        }
+    }
+    for (int i = 0; i < columnCount; i++) {
+        table.getColumn(i).pack();
+    }
+    Rectangle clientArea = shell.getClientArea();
+    table.setLocation(clientArea.x, clientArea.y);
+    Point size = table.computeSize(SWT.DEFAULT, 200);
+    table.setSize(size);
+    shell.pack();
+    table.addListener(SWT.MouseDown, new class Listener {
+        override void handleEvent(Event event) {
+            Point pt = new Point(event.x, event.y);
+            TableItem item = table.getItem(pt);
+            if (item is null)
+                return;
+            for (int i = 0; i < columnCount; i++) {
+                Rectangle rect = item.getBounds(i);
+                if (rect.contains(pt)) {
+                    int index = table.indexOf(item);
+                    writeln("Item ", index, "-", i);
+                }
+            }
+        }
+    });
+    shell.open();
+    while (!shell.isDisposed()) {
+        if (!display.readAndDispatch()) display.sleep();
+    }
+    display.dispose();
+}

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet4.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet4.d
@@ -1,0 +1,88 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet4"
+    dependency "dwt" path="../../../../../../" version="*"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "gio-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Lars Vogel <Lars.Vogel@vogella.com> - Bug 502845
+ * D Port:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.snippets.Snippet4;
+
+/*
+ * Shell example snippet: prevent escape from closing a dialog
+ *
+ * For a list of all SWT example snippets see
+ * http://www.eclipse.org/swt/snippets/
+ */
+import org.eclipse.swt.events.SelectionAdapter;
+
+import org.eclipse.swt.all;
+import org.eclipse.swt.graphics.all;
+import org.eclipse.swt.widgets.all;
+
+void main(string[] args) {
+    Display display = new Display();
+    Shell shell = new Shell(display);
+    Button b = new Button(shell, SWT.PUSH);
+    b.setText("Open Dialog ...");
+    b.pack();
+    Rectangle clientArea = shell.getClientArea();
+    b.setLocation(clientArea.x + 10, clientArea.y + 10);
+    b.addSelectionListener(new class SelectionAdapter {
+        override void widgetSelected(SelectionEvent e) {
+            Shell dialog = new Shell(shell, SWT.DIALOG_TRIM);
+            dialog.addTraverseListener(new class TraverseListener {
+                override void keyTraversed(TraverseEvent t) {
+                    if (t.detail == SWT.TRAVERSE_ESCAPE) {
+                        t.doit = false;
+                    }
+                }
+            });
+            dialog.open();
+        }
+        override void widgetDefaultSelected(SelectionEvent e) {}
+    });
+    shell.open();
+    while (!shell.isDisposed()) {
+        if (!display.readAndDispatch()) display.sleep();
+    }
+    display.dispose();
+}

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet5.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet5.d
@@ -1,0 +1,89 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet5"
+    dependency "dwt" path="../../../../../../" version="*"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "gio-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+/*******************************************************************************
+ * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * D Port:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.snippets.Snippet5;
+
+/*
+ * ScrolledComposite example snippet: scroll a control in a scrolled composite
+ *
+ * For a list of all SWT example snippets see
+ * http://www.eclipse.org/swt/snippets/
+ */
+import org.eclipse.swt.all;
+import org.eclipse.swt.custom.all;
+import org.eclipse.swt.layout.all;
+import org.eclipse.swt.widgets.all;
+
+void main(string[] args) {
+    Display display = new Display();
+    Shell shell = new Shell(display);
+    shell.setLayout(new FillLayout());
+
+    // this button is always 400 x 400. Scrollbars appear if the window is resized to be
+    // too small to show part of the button
+    ScrolledComposite c1 = new ScrolledComposite(shell, SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
+    Button b1 = new Button(c1, SWT.PUSH);
+    b1.setText("fixed size button");
+    b1.setSize(400, 400);
+    c1.setContent(b1);
+
+    // this button has a minimum size of 400 x 400. If the window is resized to be big
+    // enough to show more than 400 x 400, the button will grow in size. If the window
+    // is made too small to show 400 x 400, scrollbars will appear.
+    ScrolledComposite c2 = new ScrolledComposite(shell, SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL);
+    Button b2 = new Button(c2, SWT.PUSH);
+    b2.setText("expanding button");
+    c2.setContent(b2);
+    c2.setExpandHorizontal(true);
+    c2.setExpandVertical(true);
+    c2.setMinSize(400, 400);
+
+    shell.setSize(600, 300);
+    shell.open();
+    while (!shell.isDisposed()) {
+        if (!display.readAndDispatch()) display.sleep();
+    }
+    display.dispose();
+}

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet6.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet6.d
@@ -1,0 +1,90 @@
+#!/usr/bin/env dub
+/+
+dub.sdl:
+    name "snippet6"
+    dependency "dwt" path="../../../../../../" version="*"
+    libs \
+      "atk-1.0" \
+      "cairo" \
+      "dl" \
+      "fontconfig" \
+      "gdk-x11-2.0" \
+      "gdk_pixbuf-2.0" \
+      "gio-2.0" \
+      "glib-2.0" \
+      "gmodule-2.0" \
+      "gobject-2.0" \
+      "gthread-2.0" \
+      "gtk-x11-2.0" \
+      "pango-1.0" \
+      "pangocairo-1.0" \
+      "X11" \
+      "Xcomposite" \
+      "Xcursor" \
+      "Xdamage" \
+      "Xext" \
+      "Xfixes" \
+      "Xi" \
+      "Xinerama" \
+      "Xrandr" \
+      "Xrender" \
+      "Xtst" \
+      platform="linux"
++/
+/*******************************************************************************
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * D Port:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.snippets.Snippet6;
+
+/*
+ * GridLayout example snippet: insert widgets into a grid layout
+ *
+ * For a list of all SWT example snippets see
+ * http://www.eclipse.org/swt/snippets/
+ */
+import org.eclipse.swt.all;
+import org.eclipse.swt.layout.all;
+import org.eclipse.swt.widgets.all;
+
+void main(string[] args) {
+    Display display = new Display();
+    Shell shell = new Shell(display);
+    shell.setLayout(new GridLayout());
+    Composite c = new Composite(shell, SWT.NONE);
+    GridLayout layout = new GridLayout();
+    layout.numColumns = 3;
+    c.setLayout(layout);
+    for (int i = 0; i < 10; i++) {
+        Button b = new Button(c, SWT.PUSH);
+        b.setText("Button " ~ i.toString);
+    }
+
+    Button b = new Button(shell, SWT.PUSH);
+    b.setText("add a new button at row 2 column 1");
+    int[] index = new int[1];
+    b.addListener(SWT.Selection, new class Listener {
+        override void handleEvent (Event e) {
+            Button s = new Button(c, SWT.PUSH);
+            s.setText("Special " ~ index[0].toString);
+            index[0]++;
+            Control[] children = c.getChildren();
+            s.moveAbove(children[3]);
+            shell.layout([s]);
+        }
+    });
+
+    shell.open();
+    while (!shell.isDisposed()) {
+        if (!display.readAndDispatch()) display.sleep();
+    }
+    display.dispose();
+}

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet7.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet7.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \
@@ -34,7 +33,7 @@ dub.sdl:
 +/
 
 /*******************************************************************************
- * Copyright (c) 2000, 2004 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -65,13 +64,8 @@ import org.eclipse.swt.widgets.TableItem;
 
 import java.lang.all;
 
-version(Tango){
-    import T = tango.core.Thread;
-    import tango.util.Convert;
-} else { // Phobos
-    import T = core.thread;
-    import std.conv;
-}
+import T = core.thread;
+import std.conv;
 
 void main () {
     Display display = new Display ();

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet8.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet8.d
@@ -2,7 +2,7 @@
 /+
 dub.sdl:
     name "snippet8"
-    dependency "dwt" path="../../../../../../"
+    dependency "dwt" path="../../../../../../" version="*"
     libs \
       "atk-1.0" \
       "cairo" \
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \
@@ -34,7 +33,7 @@ dub.sdl:
 +/
 
 /*******************************************************************************
- * Copyright (c) 2000, 2004 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -65,29 +64,27 @@ import org.eclipse.swt.widgets.Tree;
 import org.eclipse.swt.widgets.TreeItem;
 
 import java.lang.all;
-version(Tango){
-    import tango.io.FilePath;
-    import tango.io.FileSystem;
-} else { // Phobos
-    import std.file;
-    import std.path;
-    class FileSystem {
-        static string[] roots() {return [absolutePath(dirSeparator)];}
-    }
-    class FilePath {
-        string path;
-        this (string path) {this.path = path;}
-        FilePath[] toList() {
-            FilePath[] r;
-            foreach (string file; dirEntries(path, SpanMode.shallow)) {
-                r ~= new FilePath(std.path.buildPath(path, file));
-            }
-            return r;
+
+import std.file;
+import std.path;
+
+/* DWT Compatibility */
+class FileSystem {
+    static string[] roots() {return [absolutePath(dirSeparator)];}
+}
+class FilePath {
+    string path;
+    this (string path) {this.path = path;}
+    FilePath[] toList() {
+        FilePath[] r;
+        foreach (string file; dirEntries(path, SpanMode.shallow)) {
+            r ~= new FilePath(std.path.buildPath(path, file));
         }
-        bool isFolder() {return exists(path) && isDir(path);}
-        override
-        string toString() {return path;}
+        return r;
     }
+    bool isFolder() {return exists(path) && isDir(path);}
+    override
+    string toString() {return path;}
 }
 
 void main () {

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet9.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet9.d
@@ -2,7 +2,7 @@
 /+
 dub.sdl:
     name "snippet9"
-    dependency "dwt" path="../../../../../../"
+    dependency "dwt" path="../../../../../../" version="*"
     libs \
       "atk-1.0" \
       "cairo" \
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \
@@ -34,7 +33,7 @@ dub.sdl:
 +/
 
 /*******************************************************************************
- * Copyright (c) 2000, 2004 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -119,6 +118,7 @@ void main () {
             composite.setLocation (location);
         }
     });
+    shell.setSize(600, 500);
     shell.open ();
     while (!shell.isDisposed()) {
         if (!display.readAndDispatch ()) display.sleep ();


### PR DESCRIPTION
I noticed there are some non-translated snippets.  This pull request adds snippets 1 - 6, and updates 7 - 10.

I tested these on a Windows VM as well and they worked, though the x86 VM required `--arch=x86`. Judging from issue #61 and the release notes of [dub 1.23], it's probably the same issue.

[dub 1.23]: https://github.com/dlang/dub/releases/tag/v1.23.0