### PR TITLE
Import 'java.io.OutputStream.OutputStream' properly

### DIFF
--- a/base/src/java/util/zip/DeflaterOutputStream.d
+++ b/base/src/java/util/zip/DeflaterOutputStream.d
@@ -3,6 +3,8 @@
  */
 module java.util.zip.DeflaterOutputStream;
 
+static import java.io.OutputStream;
+
 version (Tango) {
     version (Windows) {
         pragma (lib, "zlib.lib");


### PR DESCRIPTION
`java.io.OutputStream.OutputStream` was used a few times without any importing but it worked due to [DMD bug](https://github.com/dlang/dmd/pull/12215).