### PR TITLE
Wrong handling of a multibyte character in VerifyEvent.

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
@@ -33,6 +33,13 @@ import org.eclipse.swt.widgets.Control;
 
 import java.lang.all;
 
+version(Tango){
+    import tango.text.convert.Utf;
+} else {
+    import std.conv;
+    alias to!(string) toString;
+}
+
 /**
  * Instances of this class are selectable user interface
  * objects that allow the user to enter and modify text.
@@ -1406,7 +1413,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
     }
     if (event.character is 0) return true;
     if (!hooks (SWT.Verify) && !filters (SWT.Verify)) return true;
-    char key = cast(char) event.character;
+    wchar key = event.character;
     int stateMask = event.stateMask;
 
     /*
@@ -1483,7 +1490,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
             break;
         default:    /* Tab and other characters */
             if (key !is '\t' && key < 0x20) return true;
-            oldText = [key];
+            oldText = .toString(key);
             break;
     }
     String newText = verifyText (oldText, start, end, event);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
@@ -33,12 +33,7 @@ import org.eclipse.swt.widgets.Control;
 
 import java.lang.all;
 
-version(Tango){
-    import tango.text.convert.Utf;
-} else {
-    import std.conv;
-    alias to!(string) toString;
-}
+import std.conv;
 
 /**
  * Instances of this class are selectable user interface
@@ -1490,7 +1485,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
             break;
         default:    /* Tab and other characters */
             if (key !is '\t' && key < 0x20) return true;
-            oldText = .toString(key);
+            oldText = .to!string(key);
             break;
     }
     String newText = verifyText (oldText, start, end, event);


### PR DESCRIPTION
VerifyEvent.character is wchar, but since it is cast to char, a result will be wrong when handling a multibyte character.
For example, the character `」` will be misrecognized as a `\r\n`.