### PR TITLE
Add AccessibleAction* classes

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionAdapter.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionAdapter.d
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D programming language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.accessibility.AccessibleActionAdapter;
+
+import org.eclipse.swt.accessibility.AccessibleActionEvent;
+import org.eclipse.swt.accessibility.AccessibleActionListener;
+
+/**
+ * This adapter class provides default implementations for the
+ * methods in the <code>AccessibleActionListener</code> interface.
+ * <p>
+ * Classes that wish to deal with <code>AccessibleAction</code> events can
+ * extend this class and override only the methods that they are
+ * interested in.
+ * </p>
+ *
+ * @see AccessibleActionListener
+ * @see AccessibleActionEvent
+ *
+ * @since 3.6
+ */
+public class AccessibleActionAdapter : AccessibleActionListener {
+    /**
+     * Returns the number of accessible actions available in this object.
+     * <p>
+     * If there are more than one, the first one (index 0) is considered the
+     * "default" action of the object.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[out] count - the number of actions, or zero if there are no actions</li>
+     * </ul>
+     */
+    public void getActionCount(AccessibleActionEvent e) {}
+
+    /**
+     * Performs the specified action on the object.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying the action to perform.
+     * 		If the index lies outside the valid range no action is performed.</li>
+     * <li>[out] result - set to {@link ACC#OK} if the action was performed.</li>
+     * </ul>
+     */
+    public void doAction(AccessibleActionEvent e) {}
+
+    /**
+     * Returns a description of the specified action.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's description to return</li>
+     * <li>[out] result - a localized string describing the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getDescription(AccessibleActionEvent e) {}
+
+    /**
+     * Returns a string representing one or more key bindings, if there
+     * are any, associated with the specified action.
+     * <p>
+     * The returned string is of the following form: mnemonic;accelerator
+     * for example: "C;CTRL+C" for the Copy item in a typical Edit menu.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's key bindings to return</li>
+     * <li>[out] result - a semicolon-delimited string of localized key bindings
+     * 		(example: "C;CTRL+C"), or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getKeyBinding(AccessibleActionEvent e) {}
+
+    /**
+     * Returns the name of the specified action.
+     * <p>
+     * There is no need to implement this method for single action controls
+     * since that would be redundant with AccessibleControlListener.getDefaultAction.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's name to return</li>
+     * <li>[in] localized - a boolean indicating whether or not to return a localized name</li>
+     * <li>[out] result - the name of the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getName(AccessibleActionEvent e) {}
+}

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D programming language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.accessibility.AccessibleActionEvent;
+
+import org.eclipse.swt.internal.SWTEventObject;
+
+import java.lang.all;
+
+/**
+ * Instances of this class are sent as a result of accessibility clients
+ * sending AccessibleAction messages to an accessible object.
+ *
+ * @see AccessibleActionListener
+ * @see AccessibleActionAdapter
+ *
+ * @since 3.6
+ */
+public class AccessibleActionEvent : SWTEventObject {
+
+    /**
+     * The value of this field must be set in the accessible action listener method
+     * before returning. What to set it to depends on the listener method called.
+     */
+    public String result;
+    public int count;
+    public int index;
+    public bool localized;
+
+    // static const long serialVersionUID = 2849066792640153087L;
+
+/**
+ * Constructs a new instance of this class.
+ *
+ * @param source the object that fired the event
+ */
+public this(Object source) {
+    super(source);
+}
+
+/**
+ * Returns a string containing a concise, human-readable
+ * description of the receiver.
+ *
+ * @return a string representation of the event
+ */
+override
+public String toString() const {
+    return Format("AccessibleActionEvent {{string={} count={} index={}}",
+        result,
+        count,
+        index);
+}
+}

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionListener.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionListener.d
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D programming language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.accessibility.AccessibleActionListener;
+
+import org.eclipse.swt.internal.SWTEventListener;
+
+import org.eclipse.swt.accessibility.AccessibleActionEvent;
+
+/**
+ * Classes which implement this interface provide methods
+ * that handle AccessibleAction events.
+ * <p>
+ * After creating an instance of a class that implements
+ * this interface it can be added to an accessible using the
+ * <code>addAccessibleActionListener</code> method and removed using
+ * the <code>removeAccessibleActionListener</code> method.
+ * </p>
+ *
+ * @see AccessibleActionAdapter
+ * @see AccessibleActionEvent
+ *
+ * @since 3.6
+ */
+public interface AccessibleActionListener : SWTEventListener {
+    /**
+     * Returns the number of accessible actions available in this object.
+     * <p>
+     * If there are more than one, the first one (index 0) is considered the
+     * "default" action of the object.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[out] count - the number of actions, or zero if there are no actions</li>
+     * </ul>
+     */
+    public void getActionCount(AccessibleActionEvent e);
+
+    /**
+     * Performs the specified action on the object.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying the action to perform.
+     * 		If the index lies outside the valid range no action is performed.</li>
+     * <li>[out] result - set to {@link ACC#OK} if the action was performed.</li>
+     * </ul>
+     */
+    public void doAction(AccessibleActionEvent e);
+
+    /**
+     * Returns a description of the specified action.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's description to return</li>
+     * <li>[out] result - a localized string describing the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getDescription(AccessibleActionEvent e);
+
+    /**
+     * Returns a string representing one or more key bindings, if there
+     * are any, associated with the specified action.
+     * <p>
+     * The returned string is of the following form: mnemonic;accelerator
+     * for example: "C;CTRL+C" for the Copy item in a typical Edit menu.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's key bindings to return</li>
+     * <li>[out] result - a semicolon-delimited string of localized key bindings
+     * 		(example: "C;CTRL+C"), or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getKeyBinding(AccessibleActionEvent e);
+
+    /**
+     * Returns the name of the specified action.
+     * <p>
+     * There is no need to implement this method for single action controls
+     * since that would be redundant with AccessibleControlListener.getDefaultAction.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's name to return</li>
+     * <li>[in] localized - a boolean indicating whether or not to return a localized name</li>
+     * <li>[out] result - the name of the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getName(AccessibleActionEvent e);
+}

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/all.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/all.d
@@ -5,6 +5,9 @@ import java.lang.all;
 public import org.eclipse.swt.accessibility.ACC;
 public import org.eclipse.swt.accessibility.Accessible;
 public import org.eclipse.swt.accessibility.AccessibleAdapter;
+public import org.eclipse.swt.accessibility.AccessibleActionAdapter;
+public import org.eclipse.swt.accessibility.AccessibleActionEvent;
+public import org.eclipse.swt.accessibility.AccessibleActionListener;
 public import org.eclipse.swt.accessibility.AccessibleControlAdapter;
 public import org.eclipse.swt.accessibility.AccessibleControlEvent;
 public import org.eclipse.swt.accessibility.AccessibleControlListener;
@@ -15,5 +18,3 @@ public import org.eclipse.swt.accessibility.AccessibleObject;
 public import org.eclipse.swt.accessibility.AccessibleTextAdapter;
 public import org.eclipse.swt.accessibility.AccessibleTextEvent;
 public import org.eclipse.swt.accessibility.AccessibleTextListener;
-
-

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionAdapter.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionAdapter.d
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2016 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D programming language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.accessibility.AccessibleActionAdapter;
+
+import org.eclipse.swt.accessibility.AccessibleActionEvent;
+import org.eclipse.swt.accessibility.AccessibleActionListener;
+
+/**
+ * This adapter class provides default implementations for the
+ * methods in the <code>AccessibleActionListener</code> interface.
+ * <p>
+ * Classes that wish to deal with <code>AccessibleAction</code> events can
+ * extend this class and override only the methods that they are
+ * interested in.
+ * </p>
+ *
+ * @see AccessibleActionListener
+ * @see AccessibleActionEvent
+ *
+ * @since 3.6
+ */
+public class AccessibleActionAdapter : AccessibleActionListener {
+    /**
+     * Returns the number of accessible actions available in this object.
+     * <p>
+     * If there are more than one, the first one (index 0) is considered the
+     * "default" action of the object.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[out] count - the number of actions, or zero if there are no actions</li>
+     * </ul>
+     */
+    public void getActionCount(AccessibleActionEvent e) {}
+
+    /**
+     * Performs the specified action on the object.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying the action to perform.
+     * 		If the index lies outside the valid range no action is performed.</li>
+     * <li>[out] result - set to {@link ACC#OK} if the action was performed.</li>
+     * </ul>
+     */
+    public void doAction(AccessibleActionEvent e) {}
+
+    /**
+     * Returns a description of the specified action.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's description to return</li>
+     * <li>[out] result - a localized string describing the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getDescription(AccessibleActionEvent e) {}
+
+    /**
+     * Returns a string representing one or more key bindings, if there
+     * are any, associated with the specified action.
+     * <p>
+     * The returned string is of the following form: mnemonic;accelerator
+     * for example: "C;CTRL+C" for the Copy item in a typical Edit menu.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's key bindings to return</li>
+     * <li>[out] result - a semicolon-delimited string of localized key bindings
+     * 		(example: "C;CTRL+C"), or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getKeyBinding(AccessibleActionEvent e) {}
+
+    /**
+     * Returns the name of the specified action.
+     * <p>
+     * There is no need to implement this method for single action controls
+     * since that would be redundant with AccessibleControlListener.getDefaultAction.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's name to return</li>
+     * <li>[in] localized - a boolean indicating whether or not to return a localized name</li>
+     * <li>[out] result - the name of the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getName(AccessibleActionEvent e) {}
+}

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2017 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D programming language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.accessibility.AccessibleActionEvent;
+
+import org.eclipse.swt.internal.SWTEventObject;
+
+import java.lang.all;
+
+/**
+ * Instances of this class are sent as a result of accessibility clients
+ * sending AccessibleAction messages to an accessible object.
+ *
+ * @see AccessibleActionListener
+ * @see AccessibleActionAdapter
+ *
+ * @since 3.6
+ */
+public class AccessibleActionEvent : SWTEventObject {
+
+    /**
+     * The value of this field must be set in the accessible action listener method
+     * before returning. What to set it to depends on the listener method called.
+     */
+    public String result;
+    public int count;
+    public int index;
+    public bool localized;
+
+    // static const long serialVersionUID = 2849066792640153087L;
+
+/**
+ * Constructs a new instance of this class.
+ *
+ * @param source the object that fired the event
+ */
+public this(Object source) {
+    super(source);
+}
+
+/**
+ * Returns a string containing a concise, human-readable
+ * description of the receiver.
+ *
+ * @return a string representation of the event
+ */
+override
+public String toString() const {
+    return Format("AccessibleActionEvent {{string={} count={} index={}}",
+        result,
+        count,
+        index);
+}
+}

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionListener.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionListener.d
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2009, 2010 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ * Port to the D programming language:
+ *     alice <stigma@disroot.org>
+ *******************************************************************************/
+module org.eclipse.swt.accessibility.AccessibleActionListener;
+
+import org.eclipse.swt.internal.SWTEventListener;
+
+import org.eclipse.swt.accessibility.AccessibleActionEvent;
+
+/**
+ * Classes which implement this interface provide methods
+ * that handle AccessibleAction events.
+ * <p>
+ * After creating an instance of a class that implements
+ * this interface it can be added to an accessible using the
+ * <code>addAccessibleActionListener</code> method and removed using
+ * the <code>removeAccessibleActionListener</code> method.
+ * </p>
+ *
+ * @see AccessibleActionAdapter
+ * @see AccessibleActionEvent
+ *
+ * @since 3.6
+ */
+public interface AccessibleActionListener : SWTEventListener {
+    /**
+     * Returns the number of accessible actions available in this object.
+     * <p>
+     * If there are more than one, the first one (index 0) is considered the
+     * "default" action of the object.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[out] count - the number of actions, or zero if there are no actions</li>
+     * </ul>
+     */
+    public void getActionCount(AccessibleActionEvent e);
+
+    /**
+     * Performs the specified action on the object.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying the action to perform.
+     * 		If the index lies outside the valid range no action is performed.</li>
+     * <li>[out] result - set to {@link ACC#OK} if the action was performed.</li>
+     * </ul>
+     */
+    public void doAction(AccessibleActionEvent e);
+
+    /**
+     * Returns a description of the specified action.
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's description to return</li>
+     * <li>[out] result - a localized string describing the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getDescription(AccessibleActionEvent e);
+
+    /**
+     * Returns a string representing one or more key bindings, if there
+     * are any, associated with the specified action.
+     * <p>
+     * The returned string is of the following form: mnemonic;accelerator
+     * for example: "C;CTRL+C" for the Copy item in a typical Edit menu.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's key bindings to return</li>
+     * <li>[out] result - a semicolon-delimited string of localized key bindings
+     * 		(example: "C;CTRL+C"), or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getKeyBinding(AccessibleActionEvent e);
+
+    /**
+     * Returns the name of the specified action.
+     * <p>
+     * There is no need to implement this method for single action controls
+     * since that would be redundant with AccessibleControlListener.getDefaultAction.
+     * </p>
+     *
+     * @param e an event object containing the following fields:<ul>
+     * <li>[in] index - a 0 based index specifying which action's name to return</li>
+     * <li>[in] localized - a boolean indicating whether or not to return a localized name</li>
+     * <li>[out] result - the name of the specified action,
+     * 		or null if the index lies outside the valid range</li>
+     * </ul>
+     */
+    public void getName(AccessibleActionEvent e);
+}

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/all.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/all.d
@@ -2,6 +2,9 @@ module org.eclipse.swt.accessibility.all;
 
 public import org.eclipse.swt.accessibility.ACC;
 public import org.eclipse.swt.accessibility.Accessible;
+public import org.eclipse.swt.accessibility.AccessibleActionAdapter;
+public import org.eclipse.swt.accessibility.AccessibleActionEvent;
+public import org.eclipse.swt.accessibility.AccessibleActionListener;
 public import org.eclipse.swt.accessibility.AccessibleAdapter;
 public import org.eclipse.swt.accessibility.AccessibleControlAdapter;
 public import org.eclipse.swt.accessibility.AccessibleControlEvent;
@@ -11,5 +14,3 @@ public import org.eclipse.swt.accessibility.AccessibleListener;
 public import org.eclipse.swt.accessibility.AccessibleTextAdapter;
 public import org.eclipse.swt.accessibility.AccessibleTextEvent;
 public import org.eclipse.swt.accessibility.AccessibleTextListener;
-
-


### PR DESCRIPTION
Add the AccessibleActionAdapter, AccessibleActionEvent, and AccessibleActionListener classes.

Since these are a part of the "common" directory in SWT — and there is nothing platform specific here — did you want me to add the classes for the Windows version in this pull request?