### PR TITLE
Add const to some win32 member functions

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/custom/StyleRange.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/custom/StyleRange.d
@@ -195,7 +195,7 @@ public /+override+/ Object clone() {
  *
  * @return a string representation of the StyleRange
  */
-public override String toString() {
+public override String toString() const {
     StringBuffer buffer = new StringBuffer();
     buffer.append("StyleRange {");
     buffer.append(start);

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Color.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Color.d
@@ -167,7 +167,7 @@ public override equals_t opEquals (Object object) {
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>
  * </ul>
  */
-public int getBlue () {
+public int getBlue () const {
     if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
     return (handle & 0xFF0000) >> 16;
 }
@@ -181,7 +181,7 @@ public int getBlue () {
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>
  * </ul>
  */
-public int getGreen () {
+public int getGreen () const {
     if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
     return (handle & 0xFF00) >> 8 ;
 }
@@ -195,7 +195,7 @@ public int getGreen () {
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>
  * </ul>
  */
-public int getRed () {
+public int getRed () const {
     if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
     return handle & 0xFF;
 }
@@ -209,7 +209,7 @@ public int getRed () {
  *    <li>ERROR_GRAPHIC_DISPOSED - if the receiver has been disposed</li>
  * </ul>
  */
-public RGB getRGB () {
+public RGB getRGB () const {
     if (isDisposed()) SWT.error(SWT.ERROR_GRAPHIC_DISPOSED);
     return new RGB(cast(int)handle & 0xFF,cast(int) (handle & 0xFF00) >> 8,cast(int) (handle & 0xFF0000) >> 16);
 }
@@ -301,7 +301,7 @@ void init_(int red, int green, int blue) {
  *
  * @return <code>true</code> when the color is disposed and <code>false</code> otherwise
  */
-override public bool isDisposed() {
+override public bool isDisposed() const {
     return handle is -1;
 }
 
@@ -311,7 +311,7 @@ override public bool isDisposed() {
  *
  * @return a string representation of the receiver
  */
-override public String toString () {
+override public String toString () const {
     if (isDisposed()) return "Color {*DISPOSED*}"; //$NON-NLS-1$
     return Format( "Color {{{}, {}, {}}", getRed(), getGreen(), getBlue()); //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Font.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Font.d
@@ -233,7 +233,7 @@ void init_ (FontData fd) {
  *
  * @return <code>true</code> when the font is disposed and <code>false</code> otherwise
  */
-override public bool isDisposed() {
+override public bool isDisposed() const {
     return handle is null;
 }
 
@@ -243,7 +243,7 @@ override public bool isDisposed() {
  *
  * @return a string representation of the receiver
  */
-override public String toString () {
+override public String toString () const {
     if (isDisposed()) return "Font {*DISPOSED*}";
     return Format( "Font {{{}}", handle );
 //

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/GlyphMetrics.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/GlyphMetrics.d
@@ -112,7 +112,7 @@ public override hash_t toHash () {
  *
  * @return a string representation of the <code>GlyphMetrics</code>
  */
-public override String toString () {
+public override String toString () const {
     return Format( "GlyphMetrics {{{}, {}, {}}", ascent, descent, width ); //$NON-NLS-1$//$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 }
 

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/TextStyle.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/TextStyle.d
@@ -174,7 +174,7 @@ public this (Font font, Color foreground, Color background) {
 /**
  * Create a new text style from an existing text style.
  *
- * @param style the style to copy 
+ * @param style the style to copy
  *
  * @since 3.4
  */
@@ -300,7 +300,7 @@ bool isAdherentStrikeout(TextStyle style) {
  *
  * @return a string representation of the <code>TextStyle</code>
  */
-override public String toString () {
+override public String toString () const {
     String buffer = "TextStyle {";
     int startLength = cast(int)/*64bit*/buffer.length;
     if (font !is null) {


### PR DESCRIPTION
Probably should have included these in #82, since it's for the same reason.

There is a difference between this pull request and the last, which is the changes in the `Color` class. That's because the Gtk `Color` has been updated to 4.7.3 (`const` was added then, see #75) but the win32 version has not been updated.