### PR TITLE
Update Accessibility classes to 4.7.3

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
@@ -12,9 +12,8 @@
  *******************************************************************************/
 module org.eclipse.swt.accessibility.AccessibleActionEvent;
 
-import org.eclipse.swt.internal.SWTEventObject;
-
 import java.lang.all;
+import java.util.EventObject;
 
 /**
  * Instances of this class are sent as a result of accessibility clients
@@ -25,7 +24,7 @@ import java.lang.all;
  *
  * @since 3.6
  */
-public class AccessibleActionEvent : SWTEventObject {
+public class AccessibleActionEvent : EventObject {
 
     /**
      * The value of this field must be set in the accessible action listener method

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleAdapter.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleAdapter.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleControlAdapter.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleControlAdapter.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -84,18 +84,22 @@ public abstract class AccessibleControlAdapter : AccessibleControlListener {
 
     /**
      * Sent when an accessibility client requests the accessible object
-     * for a child of the control.
-     * The default behavior is to do nothing.
+     * for a child of the control by index or childID, or when a client
+     * requests the index of an accessible object in its parent.
      * <p>
-     * Return an <code>Accessible</code> for the specified control or
-     * child in the <code>accessible</code> field of the event object.
-     * Return null if the specified child does not have its own
-     * <code>Accessible</code>.
-     * </p>
+     * The childID field in the event object can be one of the following:<ul>
+     *    <li>an integer child ID - return the accessible object for the specified child ID,
+     *    	or null if the specified child does not have its own accessible</li>
+     *    <li>{@link ACC#CHILDID_CHILD_AT_INDEX} - return the accessible child object at the specified index,
+     *    	or null if this object has no children</li>
+     *    <li>{@link ACC#CHILDID_CHILD_INDEX} - return the index of this accessible in its parent</li>
+     * </ul></p>
      *
      * @param e an event object containing the following fields:<ul>
-     *    <li>childID [IN] - an identifier specifying a child of the control</li>
-     *    <li>accessible [OUT] - an Accessible for the specified childID, or null if one does not exist</li>
+     *    <li>childID [IN] - an identifier specifying a child of the control, or one of the predefined CHILDID constants</li>
+     *    <li>detail [Optional IN] - the index of the child accessible to be returned when childID = CHILDID_CHILD_AT_INDEX</li>
+     *    <li>detail [Optional OUT] - the index of this accessible in its parent when childID = CHILDID_CHILD_INDEX</li>
+     *    <li>accessible [Optional OUT] - an Accessible for the specified childID or index, or null if one does not exist</li>
      * </ul>
      */
     public void getChild(AccessibleControlEvent e) {
@@ -190,6 +194,7 @@ public abstract class AccessibleControlAdapter : AccessibleControlListener {
      *
      * @param e an event object containing the following fields:<ul>
      *    <li>childID [Typical OUT] - the ID of the selected child, or CHILDID_SELF, or CHILDID_MULTIPLE, or CHILDID_NONE</li>
+     *    <li>children [Optional OUT] - the array of childIDs for the selected children if CHILDID_MULTIPLE is returned</li>
      *    <li>accessible [Optional OUT] - the accessible object for the control or child may be returned instead of the childID</li>
      * </ul>
      */
@@ -239,16 +244,20 @@ public abstract class AccessibleControlAdapter : AccessibleControlListener {
     }
 
     /**
-     * Sent when an accessibility client requests the children of the control.
-     * The default behavior is to do nothing.
+     * Sent when an accessibility client requests the children, or visible children,
+     * of the control. The default behavior is to do nothing.
      * <p>
-     * Return the children as an array of childIDs in the <code>children</code>
-     * field of the event object.
+     * Return the children as an array of childIDs or accessibles in the
+     * <code>children</code> field of the event object.
      * </p>
      *
      * @param e an event object containing the following fields:<ul>
+     *    <li>detail [IN] - a flag that may have one of the following values:<ul>
+     *    	<li>0 (default) - return all children</li>
+     *    	<li>VISIBLE - return all visible children</li>
+     *    </ul>
      *    <li>children [Typical OUT] - an array of childIDs</li>
-     *    <li>accessible [Optional OUT] - an array of accessible objects for the children may be returned instead of the childIDs</li>
+     *    <li>children [Optional OUT] - an array of accessible objects for the children may be returned instead of the childIDs</li>
      * </ul>
      */
     public void getChildren(AccessibleControlEvent e) {

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleControlEvent.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleControlEvent.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,8 @@ module org.eclipse.swt.accessibility.AccessibleControlEvent;
 
 import org.eclipse.swt.accessibility.Accessible;
 
-import org.eclipse.swt.internal.SWTEventObject;
 import java.lang.all;
+import java.util.EventObject;
 
 /**
  * Instances of this class are sent as a result of
@@ -34,7 +34,7 @@ import java.lang.all;
  *
  * @since 2.0
  */
-public class AccessibleControlEvent : SWTEventObject {
+public class AccessibleControlEvent : EventObject {
     public int childID;         // IN/OUT
     public Accessible accessible;   // OUT
     public int x, y;                // IN/OUT
@@ -62,7 +62,7 @@ public this(Object source) {
  */
 override
 public String toString () {
-    return Format( "AccessibleControlEvent {{childID={} accessible={} x={} y={} width={} heigth={} detail={} result={}}",
+    return Format( "AccessibleControlEvent {{childID={} accessible={} x={} y={} width={} height={} detail={} result={}}",
         childID, accessible, x, y, width, height, detail, result);
 }
 }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleControlListener.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleControlListener.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2006 IBM Corporation and others.
+ * Copyright (c) 2000, 2010 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,17 +81,22 @@ public interface AccessibleControlListener : SWTEventListener {
 
     /**
      * Sent when an accessibility client requests the accessible object
-     * for a child of the control.
+     * for a child of the control by index or childID, or when a client
+     * requests the index of an accessible object in its parent.
      * <p>
-     * Return an <code>Accessible</code> for the specified control or
-     * child in the <code>accessible</code> field of the event object.
-     * Return null if the specified child does not have its own
-     * <code>Accessible</code>.
-     * </p>
+     * The childID field in the event object can be one of the following:<ul>
+     *    <li>an integer child ID - return the accessible object for the specified child ID,
+     *    	or null if the specified child does not have its own accessible</li>
+     *    <li>{@link ACC#CHILDID_CHILD_AT_INDEX} - return the accessible child object at the specified index,
+     *    	or null if this object has no children</li>
+     *    <li>{@link ACC#CHILDID_CHILD_INDEX} - return the index of this accessible in its parent</li>
+     * </ul></p>
      *
      * @param e an event object containing the following fields:<ul>
-     *    <li>childID [IN] - an identifier specifying a child of the control</li>
-     *    <li>accessible [OUT] - an Accessible for the specified childID, or null if one does not exist</li>
+     *    <li>childID [IN] - an identifier specifying a child of the control, or one of the predefined CHILDID constants</li>
+     *    <li>detail [Optional IN] - the index of the child accessible to be returned when childID = CHILDID_CHILD_AT_INDEX</li>
+     *    <li>detail [Optional OUT] - the index of this accessible in its parent when childID = CHILDID_CHILD_INDEX</li>
+     *    <li>accessible [Optional OUT] - an Accessible for the specified childID or index, or null if one does not exist</li>
      * </ul>
      */
     public void getChild(AccessibleControlEvent e);
@@ -176,6 +181,7 @@ public interface AccessibleControlListener : SWTEventListener {
      *
      * @param e an event object containing the following fields:<ul>
      *    <li>childID [Typical OUT] - the ID of the selected child, or CHILDID_SELF, or CHILDID_MULTIPLE, or CHILDID_NONE</li>
+     *    <li>children [Optional OUT] - the array of childIDs for the selected children if CHILDID_MULTIPLE is returned</li>
      *    <li>accessible [Optional OUT] - the accessible object for the control or child may be returned instead of the childID</li>
      * </ul>
      */
@@ -220,13 +226,18 @@ public interface AccessibleControlListener : SWTEventListener {
     public void getValue(AccessibleControlEvent e);
 
     /**
-     * Sent when an accessibility client requests the children of the control.
+     * Sent when an accessibility client requests the children, or visible children,
+     * of the control.
      * <p>
-     * Return the children as an array of childIDs in the <code>children</code>
-     * field of the event object.
+     * Return the children as an array of childIDs or accessibles in the
+     * <code>children</code> field of the event object.
      * </p>
      *
      * @param e an event object containing the following fields:<ul>
+     *    <li>detail [IN] - a flag that may have one of the following values:<ul>
+     *    	<li>0 (default) - return all children</li>
+     *    	<li>VISIBLE - return all visible children</li>
+     *    </ul>
      *    <li>children [Typical OUT] - an array of childIDs</li>
      *    <li>children [Optional OUT] - an array of accessible objects for the children may be returned instead of the childIDs</li>
      * </ul>

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleEvent.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleEvent.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@
 module org.eclipse.swt.accessibility.AccessibleEvent;
 
 
-import org.eclipse.swt.internal.SWTEventObject;
 import java.lang.all;
+import java.util.EventObject;
 
 /**
  * Instances of this class are sent as a result of
@@ -31,7 +31,7 @@ import java.lang.all;
  *
  * @since 2.0
  */
-public class AccessibleEvent : SWTEventObject {
+public class AccessibleEvent : EventObject {
     /**
      * The value of this field is set by an accessibility client
      * before the accessible listener method is called.

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextAdapter.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextAdapter.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextAttributeEvent.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextAttributeEvent.d
@@ -13,8 +13,8 @@
 module org.eclipse.swt.accessibility.AccessibleTextAttributeEvent;
 
 import java.lang.all;
+import java.util.EventObject;
 
-import org.eclipse.swt.internal.SWTEventObject;
 
 import org.eclipse.swt.graphics.all;
 
@@ -32,7 +32,7 @@ import std.conv : to;
  *
  * @since 3.6
  */
-public class AccessibleTextAttributeEvent : SWTEventObject {
+public class AccessibleTextAttributeEvent : EventObject {
 
     /**
      * [in] the 0-based text offset for which to return attribute information

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextEvent.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextEvent.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,17 @@
  *     IBM Corporation - initial API and implementation
  * Port to the D programming language:
  *     Frank Benoit <benoit@tionex.de>
+ *     alice <stigma@disroot.org>
  *******************************************************************************/
 module org.eclipse.swt.accessibility.AccessibleTextEvent;
 
+import org.eclipse.swt.accessibility.Accessible;
 
-import org.eclipse.swt.internal.SWTEventObject;
+
 import java.lang.all;
+import java.util.EventObject;
+
+import org.eclipse.swt.graphics.all;
 
 /**
  * Instances of this class are sent as a result of
@@ -33,9 +38,33 @@ import java.lang.all;
  *
  * @since 3.0
  */
-public class AccessibleTextEvent : SWTEventObject {
+public class AccessibleTextEvent : EventObject {
     public int childID;             // IN
     public int offset, length;      // OUT
+    /** @since 3.6 */
+    public Accessible accessible;
+
+    /**
+     * The value of this field must be set in the accessible text extended listener method
+     * before returning. What to set it to depends on the listener method called.
+     * @since 3.6
+     */
+    public String result;
+
+    /** @since 3.6 */
+    public int count;
+    /** @since 3.6 */
+    public int index;
+    /** @since 3.6 */
+    public int start, end;
+    /** @since 3.6 */
+    public int type;
+    /** @since 3.6 */
+    public int x, y, width, height;
+    /** @since 3.6 */
+    public int [] ranges;
+    /** @since 3.6 */
+    public Rectangle [] rectangles;
 
     //static final long serialVersionUID = 3977019530868308275L;
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextListener.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/accessibility/AccessibleTextListener.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2003 IBM Corporation and others.
+ * Copyright (c) 2000, 2005 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleActionEvent.d
@@ -12,9 +12,8 @@
  *******************************************************************************/
 module org.eclipse.swt.accessibility.AccessibleActionEvent;
 
-import org.eclipse.swt.internal.SWTEventObject;
-
 import java.lang.all;
+import java.util.EventObject;
 
 /**
  * Instances of this class are sent as a result of accessibility clients
@@ -25,7 +24,7 @@ import java.lang.all;
  *
  * @since 3.6
  */
-public class AccessibleActionEvent : SWTEventObject {
+public class AccessibleActionEvent : EventObject {
 
     /**
      * The value of this field must be set in the accessible action listener method

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleAdapter.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleAdapter.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleControlAdapter.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleControlAdapter.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -84,18 +84,22 @@ public abstract class AccessibleControlAdapter : AccessibleControlListener {
 
     /**
      * Sent when an accessibility client requests the accessible object
-     * for a child of the control.
-     * The default behavior is to do nothing.
+     * for a child of the control by index or childID, or when a client
+     * requests the index of an accessible object in its parent.
      * <p>
-     * Return an <code>Accessible</code> for the specified control or
-     * child in the <code>accessible</code> field of the event object.
-     * Return null if the specified child does not have its own
-     * <code>Accessible</code>.
-     * </p>
+     * The childID field in the event object can be one of the following:<ul>
+     *    <li>an integer child ID - return the accessible object for the specified child ID,
+     *    	or null if the specified child does not have its own accessible</li>
+     *    <li>{@link ACC#CHILDID_CHILD_AT_INDEX} - return the accessible child object at the specified index,
+     *    	or null if this object has no children</li>
+     *    <li>{@link ACC#CHILDID_CHILD_INDEX} - return the index of this accessible in its parent</li>
+     * </ul></p>
      *
      * @param e an event object containing the following fields:<ul>
-     *    <li>childID [IN] - an identifier specifying a child of the control</li>
-     *    <li>accessible [OUT] - an Accessible for the specified childID, or null if one does not exist</li>
+     *    <li>childID [IN] - an identifier specifying a child of the control, or one of the predefined CHILDID constants</li>
+     *    <li>detail [Optional IN] - the index of the child accessible to be returned when childID = CHILDID_CHILD_AT_INDEX</li>
+     *    <li>detail [Optional OUT] - the index of this accessible in its parent when childID = CHILDID_CHILD_INDEX</li>
+     *    <li>accessible [Optional OUT] - an Accessible for the specified childID or index, or null if one does not exist</li>
      * </ul>
      */
     public void getChild(AccessibleControlEvent e) {
@@ -190,6 +194,7 @@ public abstract class AccessibleControlAdapter : AccessibleControlListener {
      *
      * @param e an event object containing the following fields:<ul>
      *    <li>childID [Typical OUT] - the ID of the selected child, or CHILDID_SELF, or CHILDID_MULTIPLE, or CHILDID_NONE</li>
+     *    <li>children [Optional OUT] - the array of childIDs for the selected children if CHILDID_MULTIPLE is returned</li>
      *    <li>accessible [Optional OUT] - the accessible object for the control or child may be returned instead of the childID</li>
      * </ul>
      */
@@ -239,16 +244,20 @@ public abstract class AccessibleControlAdapter : AccessibleControlListener {
     }
 
     /**
-     * Sent when an accessibility client requests the children of the control.
-     * The default behavior is to do nothing.
+     * Sent when an accessibility client requests the children, or visible children,
+     * of the control. The default behavior is to do nothing.
      * <p>
-     * Return the children as an array of childIDs in the <code>children</code>
-     * field of the event object.
+     * Return the children as an array of childIDs or accessibles in the
+     * <code>children</code> field of the event object.
      * </p>
      *
      * @param e an event object containing the following fields:<ul>
+     *    <li>detail [IN] - a flag that may have one of the following values:<ul>
+     *    	<li>0 (default) - return all children</li>
+     *    	<li>VISIBLE - return all visible children</li>
+     *    </ul>
      *    <li>children [Typical OUT] - an array of childIDs</li>
-     *    <li>accessible [Optional OUT] - an array of accessible objects for the children may be returned instead of the childIDs</li>
+     *    <li>children [Optional OUT] - an array of accessible objects for the children may be returned instead of the childIDs</li>
      * </ul>
      */
     public void getChildren(AccessibleControlEvent e) {

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleControlEvent.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleControlEvent.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,8 +14,8 @@ module org.eclipse.swt.accessibility.AccessibleControlEvent;
 
 import org.eclipse.swt.accessibility.Accessible;
 
-import org.eclipse.swt.internal.SWTEventObject;
 import java.lang.all;
+import java.util.EventObject;
 
 /**
  * Instances of this class are sent as a result of
@@ -34,7 +34,7 @@ import java.lang.all;
  *
  * @since 2.0
  */
-public class AccessibleControlEvent : SWTEventObject {
+public class AccessibleControlEvent : EventObject {
     public int childID;         // IN/OUT
     public Accessible accessible;   // OUT
     public int x, y;                // IN/OUT
@@ -62,7 +62,7 @@ public this(Object source) {
  */
 override
 public String toString () {
-    return Format( "AccessibleControlEvent {{childID={} accessible={} x={} y={} width={} heigth={} detail={} result={}}",
+    return Format( "AccessibleControlEvent {{childID={} accessible={} x={} y={} width={} height={} detail={} result={}}",
         childID, accessible, x, y, width, height, detail, result);
 }
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleControlListener.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleControlListener.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2006 IBM Corporation and others.
+ * Copyright (c) 2000, 2010 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -81,17 +81,22 @@ public interface AccessibleControlListener : SWTEventListener {
 
     /**
      * Sent when an accessibility client requests the accessible object
-     * for a child of the control.
+     * for a child of the control by index or childID, or when a client
+     * requests the index of an accessible object in its parent.
      * <p>
-     * Return an <code>Accessible</code> for the specified control or
-     * child in the <code>accessible</code> field of the event object.
-     * Return null if the specified child does not have its own
-     * <code>Accessible</code>.
-     * </p>
+     * The childID field in the event object can be one of the following:<ul>
+     *    <li>an integer child ID - return the accessible object for the specified child ID,
+     *    	or null if the specified child does not have its own accessible</li>
+     *    <li>{@link ACC#CHILDID_CHILD_AT_INDEX} - return the accessible child object at the specified index,
+     *    	or null if this object has no children</li>
+     *    <li>{@link ACC#CHILDID_CHILD_INDEX} - return the index of this accessible in its parent</li>
+     * </ul></p>
      *
      * @param e an event object containing the following fields:<ul>
-     *    <li>childID [IN] - an identifier specifying a child of the control</li>
-     *    <li>accessible [OUT] - an Accessible for the specified childID, or null if one does not exist</li>
+     *    <li>childID [IN] - an identifier specifying a child of the control, or one of the predefined CHILDID constants</li>
+     *    <li>detail [Optional IN] - the index of the child accessible to be returned when childID = CHILDID_CHILD_AT_INDEX</li>
+     *    <li>detail [Optional OUT] - the index of this accessible in its parent when childID = CHILDID_CHILD_INDEX</li>
+     *    <li>accessible [Optional OUT] - an Accessible for the specified childID or index, or null if one does not exist</li>
      * </ul>
      */
     public void getChild(AccessibleControlEvent e);
@@ -176,6 +181,7 @@ public interface AccessibleControlListener : SWTEventListener {
      *
      * @param e an event object containing the following fields:<ul>
      *    <li>childID [Typical OUT] - the ID of the selected child, or CHILDID_SELF, or CHILDID_MULTIPLE, or CHILDID_NONE</li>
+     *    <li>children [Optional OUT] - the array of childIDs for the selected children if CHILDID_MULTIPLE is returned</li>
      *    <li>accessible [Optional OUT] - the accessible object for the control or child may be returned instead of the childID</li>
      * </ul>
      */
@@ -220,13 +226,18 @@ public interface AccessibleControlListener : SWTEventListener {
     public void getValue(AccessibleControlEvent e);
 
     /**
-     * Sent when an accessibility client requests the children of the control.
+     * Sent when an accessibility client requests the children, or visible children,
+     * of the control.
      * <p>
-     * Return the children as an array of childIDs in the <code>children</code>
-     * field of the event object.
+     * Return the children as an array of childIDs or accessibles in the
+     * <code>children</code> field of the event object.
      * </p>
      *
      * @param e an event object containing the following fields:<ul>
+     *    <li>detail [IN] - a flag that may have one of the following values:<ul>
+     *    	<li>0 (default) - return all children</li>
+     *    	<li>VISIBLE - return all visible children</li>
+     *    </ul>
      *    <li>children [Typical OUT] - an array of childIDs</li>
      *    <li>children [Optional OUT] - an array of accessible objects for the children may be returned instead of the childIDs</li>
      * </ul>

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleEvent.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleEvent.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -13,8 +13,8 @@
 module org.eclipse.swt.accessibility.AccessibleEvent;
 
 
-import org.eclipse.swt.internal.SWTEventObject;
 import java.lang.all;
+import java.util.EventObject;
 
 /**
  * Instances of this class are sent as a result of
@@ -31,7 +31,7 @@ import java.lang.all;
  *
  * @since 2.0
  */
-public class AccessibleEvent : SWTEventObject {
+public class AccessibleEvent : EventObject {
     /**
      * The value of this field is set by an accessibility client
      * before the accessible listener method is called.

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextAdapter.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextAdapter.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextAttributeEvent.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextAttributeEvent.d
@@ -13,8 +13,8 @@
 module org.eclipse.swt.accessibility.AccessibleTextAttributeEvent;
 
 import java.lang.all;
+import java.util.EventObject;
 
-import org.eclipse.swt.internal.SWTEventObject;
 
 import org.eclipse.swt.graphics.all;
 
@@ -32,7 +32,7 @@ import std.conv : to;
  *
  * @since 3.6
  */
-public class AccessibleTextAttributeEvent : SWTEventObject {
+public class AccessibleTextAttributeEvent : EventObject {
 
     /**
      * [in] the 0-based text offset for which to return attribute information

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextEvent.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextEvent.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2008 IBM Corporation and others.
+ * Copyright (c) 2000, 2017 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -9,12 +9,17 @@
  *     IBM Corporation - initial API and implementation
  * Port to the D programming language:
  *     Frank Benoit <benoit@tionex.de>
+ *     alice <stigma@disroot.org>
  *******************************************************************************/
 module org.eclipse.swt.accessibility.AccessibleTextEvent;
 
+import org.eclipse.swt.accessibility.Accessible;
 
-import org.eclipse.swt.internal.SWTEventObject;
+
 import java.lang.all;
+import java.util.EventObject;
+
+import org.eclipse.swt.graphics.all;
 
 /**
  * Instances of this class are sent as a result of
@@ -33,9 +38,33 @@ import java.lang.all;
  *
  * @since 3.0
  */
-public class AccessibleTextEvent : SWTEventObject {
+public class AccessibleTextEvent : EventObject {
     public int childID;             // IN
     public int offset, length;      // OUT
+    /** @since 3.6 */
+    public Accessible accessible;
+
+    /**
+     * The value of this field must be set in the accessible text extended listener method
+     * before returning. What to set it to depends on the listener method called.
+     * @since 3.6
+     */
+    public String result;
+
+    /** @since 3.6 */
+    public int count;
+    /** @since 3.6 */
+    public int index;
+    /** @since 3.6 */
+    public int start, end;
+    /** @since 3.6 */
+    public int type;
+    /** @since 3.6 */
+    public int x, y, width, height;
+    /** @since 3.6 */
+    public int [] ranges;
+    /** @since 3.6 */
+    public Rectangle [] rectangles;
 
     //static final long serialVersionUID = 3977019530868308275L;
 

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextListener.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/accessibility/AccessibleTextListener.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2003 IBM Corporation and others.
+ * Copyright (c) 2000, 2005 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
This updates the pre-existing accessibility classes to the equivalent of SWT 4.7.3.

Mostly just comments but there are some code changes, nothing that should cause breakage though.