### PR TITLE
[gtk] Fix null dereference in Display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
           - dmd-2.085.1
           - dmd-2.090.1
         arch: [x86_64]
+        buildType: [unittest]
         include:
           - os: windows-2019
             dc: dmd-latest
@@ -33,6 +34,14 @@ jobs:
           - os: windows-2019
             dc: ldc-latest
             arch: x86
+          - os: ubuntu-20.04
+            dc: dmd-latest
+            arch: x86_64
+            buildType: optimized-unittests
+          - os: ubuntu-20.04
+            dc: ldc-latest
+            arch: x86_64
+            buildType: optimized-unittests
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
@@ -62,9 +71,9 @@ jobs:
             libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxrandr-dev \
             libxrender-dev libxtst-dev
 
-      - name: Test DWT Gtk
+      - name: Test DWT Gtk (${{ matrix.buildType }})
         if: ${{ matrix.os == 'ubuntu-20.04' }}
         uses: GabrielBB/xvfb-action@v1 # X virtual framebuffer
         with:
           working-directory: ./
-          run: dub test -c unittest-gtk
+          run: dub test -c unittest-gtk -b ${{ matrix.buildType }}

--- a/dub.sdl
+++ b/dub.sdl
@@ -67,7 +67,11 @@ configuration "windows-win32" {
   dependency ":base" version="*"
 }
 
-# Test configurations
+# unittest settings
+buildType "optimized-unittests" {
+  buildOptions "optimize" "unittests"
+}
+
 configuration "unittest-gtk" {
   platforms "linux"
 

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
@@ -920,26 +920,19 @@ protected override void create (DeviceData data) {
     if (Default is null) Default = this;
 }
 
-private static extern(C) int XErrorHandler( void*, XErrorEvent* ){
-    getDwtLogger().error ( __FILE__, __LINE__, "*** XError" );
-    return 0;
-}
-
 void createDisplay (DeviceData data) {
     /* Required for g_main_context_wakeup */
     if (!OS.g_thread_supported ()) {
         OS.g_thread_init (null);
     }
     OS.gtk_set_locale();
-    int cnt = 2;
-    auto args = [ "name".ptr, "--sync".ptr, "".ptr ];
-    auto a = args.ptr;
-    if (!OS.gtk_init_check (&cnt, &a )) {
+    // DWT: Needed to pass int* to gtk_init_check
+    int argc = 0;
+    if (!OS.gtk_init_check (&argc, null)) {
+        SWT.error (SWT.ERROR_NO_HANDLES, null, " [gtk_init_check() failed]");
     }
-    assert( cnt is 1 );
     if (OS.GDK_WINDOWING_X11 ()) xDisplay = cast(void*) OS.GDK_DISPLAY ();
 
-    OS.XSetErrorHandler( &Display.XErrorHandler );
     char* ptr = OS.gtk_check_version (MAJOR, MINOR, MICRO);
     if (ptr !is null) {
         char [] buffer = fromStringz(ptr);

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Display.d
@@ -922,8 +922,6 @@ protected override void create (DeviceData data) {
 
 private static extern(C) int XErrorHandler( void*, XErrorEvent* ){
     getDwtLogger().error ( __FILE__, __LINE__, "*** XError" );
-    byte* p;
-    *p = 3;
     return 0;
 }
 
@@ -4287,4 +4285,3 @@ package struct CallbackData {
     Display display;
     void* data;
 }
-


### PR DESCRIPTION
Error was thrown when trying to build (using dub) with `-b release`. Not sure what the plan for `p` was, as SWT doesn't actually set an error handler for X in the Display class.