### PR TITLE
 Solve the compilation error of Windows platform

### DIFF
--- a/tools/build_snippets.d
+++ b/tools/build_snippets.d
@@ -54,6 +54,10 @@ bool shouldBuildSnippet(string path)
 Snippet build(string path)
 {
     auto command = ["dub", "build", "--single"] ~ options.extraArgs ~ path;
+  
+    version (Windows)
+        command ~= "--arch=x86";
+    
     immutable exitCode = spawnProcess(command).wait();
 
     if (options.failFast)


### PR DESCRIPTION
starting from 2.086, the default compiler architecture of dmd on windows platform is x86_ 64.