### PR TITLE
Update Drawable to 4.7.3

### DIFF
--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Device.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Device.d
@@ -879,4 +879,12 @@ private static extern(C)  int XIOErrorProcFunc (void* xDisplay) {
     return 0;
 }
 
+// DWT Custom
+
+// D doesn't support "default" in interfaces
+// originally in org.eclipse.swt.graphics.Drawable
+public bool isAutoScalable () {
+    return true;
+}
+
 }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Drawable.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Drawable.d
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2000, 2004 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -24,7 +24,7 @@ import org.eclipse.swt.internal.gtk.OS;
  * their associated GC. SWT images, and device objects such as the Display
  * device and the Printer device, are drawables.
  * <p>
- * <b>IMPORTANT:</b> This class is <em>not</em> part of the SWT
+ * <b>IMPORTANT:</b> This interface is <em>not</em> part of the SWT
  * public API. It is marked public only so that it can be shared
  * within the packages provided by SWT. It should never be
  * referenced from application code.
@@ -48,6 +48,8 @@ public interface Drawable {
  *
  * @param data the platform specific GC data
  * @return the platform specific GC handle
+ *
+ * @noreference This method is not intended to be referenced by clients.
  */
 
 public GdkGC* internal_new_GC (GCData data);
@@ -64,7 +66,21 @@ public GdkGC* internal_new_GC (GCData data);
  *
  * @param handle the platform specific GC handle
  * @param data the platform specific GC data
+ *
+ * @noreference This method is not intended to be referenced by clients.
  */
 public void internal_dispose_GC (GdkGC* handle, GCData data);
+
+/**
+ * Returns <code>true</code> iff coordinates can be auto-scaled on this
+ * drawable and <code>false</code> if not. E.g. a {@link GC} method should not
+ * auto-scale the bounds of a figure drawn on a Printer device, but it may have
+ * to auto-scale when drawing on a high-DPI Display monitor.
+ *
+ * @return <code>true</code> if auto-scaling is enabled for this drawable
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ */
+public bool isAutoScalable ();
 
 }

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Image.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/graphics/Image.d
@@ -1186,5 +1186,12 @@ public override String toString () {
     return Format( "Image {{{}}", pixmap);
 }
 
+// DWT Custom
+
+// D doesn't support "default" in interfaces
+// originally in org.eclipse.swt.graphics.Drawable
+public bool isAutoScalable () {
+    return true;
 }
 
+}

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/printing/Printer.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/printing/Printer.d
@@ -437,6 +437,14 @@ public override void internal_dispose_GC(GdkGC* gdkGC, GCData data) {
 }
 
 /**
+ * @noreference This method is not intended to be referenced by clients.
+ */
+override
+public bool isAutoScalable() {
+    return false;
+}
+
+/**
  * Releases any internal state prior to destroying this printer.
  * This method is called internally by the dispose
  * mechanism of the <code>Device</code> class.

--- a/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Control.d
+++ b/org.eclipse.swt.gtk.linux.x86/src/org/eclipse/swt/widgets/Control.d
@@ -4532,4 +4532,13 @@ override int windowProc (GtkWidget* handle, ptrdiff_t arg0, ptrdiff_t user_data)
     }
     return super.windowProc (handle, arg0, user_data);
 }
+
+// DWT Custom
+
+// D doesn't support "default" in interfaces
+// originally in org.eclipse.swt.graphics.Drawable
+public bool isAutoScalable () {
+    return true;
+}
+
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Device.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Device.d
@@ -951,6 +951,12 @@ public void setWarnings (bool warnings) {
     checkDevice ();
 }
 
+// DWT Custom
+
+// D doesn't support "default" in interfaces
+// originally in org.eclipse.swt.graphics.Drawable
+public bool isAutoScalable () {
+    return true;
 }
 
-
+}

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Drawable.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Drawable.d
@@ -1,5 +1,5 @@
 ﻿/*******************************************************************************
- * Copyright (c) 2000, 2004 IBM Corporation and others.
+ * Copyright (c) 2000, 2016 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -22,7 +22,7 @@ import org.eclipse.swt.internal.win32.WINTYPES;
  * their associated GC. SWT images, and device objects such as the Display
  * device and the Printer device, are drawables.
  * <p>
- * <b>IMPORTANT:</b> This class is <em>not</em> part of the SWT
+ * <b>IMPORTANT:</b> This interface is <em>not</em> part of the SWT
  * public API. It is marked public only so that it can be shared
  * within the packages provided by SWT. It should never be
  * referenced from application code.
@@ -46,6 +46,8 @@ public interface Drawable {
  *
  * @param data the platform specific GC data
  * @return the platform specific GC handle
+ *
+ * @noreference This method is not intended to be referenced by clients.
  */
 
 public HDC internal_new_GC (GCData data);
@@ -62,7 +64,21 @@ public HDC internal_new_GC (GCData data);
  *
  * @param handle the platform specific GC handle
  * @param data the platform specific GC data
+ *
+ * @noreference This method is not intended to be referenced by clients.
  */
 public void internal_dispose_GC ( HDC handle, GCData data);
+
+/**
+ * Returns <code>true</code> iff coordinates can be auto-scaled on this
+ * drawable and <code>false</code> if not. E.g. a {@link GC} method should not
+ * auto-scale the bounds of a figure drawn on a Printer device, but it may have
+ * to auto-scale when drawing on a high-DPI Display monitor.
+ *
+ * @return <code>true</code> if auto-scaling is enabled for this drawable
+ *
+ * @noreference This method is not intended to be referenced by clients.
+ */
+public bool isAutoScalable ();
 
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Image.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/graphics/Image.d
@@ -2156,4 +2156,12 @@ public static Image win32_new(Device device, int type, HGDIOBJ handle) {
     return image;
 }
 
+// DWT Custom
+
+// D doesn't support "default" in interfaces
+// originally in org.eclipse.swt.graphics.Drawable
+public bool isAutoScalable () {
+    return true;
+}
+
 }

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/printing/Printer.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/printing/Printer.d
@@ -284,6 +284,14 @@ public void internal_dispose_GC(HDC hDC, GCData data) {
 }
 
 /**
+ * @noreference This method is not intended to be referenced by clients.
+ */
+override
+public bool isAutoScalable() {
+    return false;
+}
+
+/**
  * Starts a print job and returns true if the job started successfully
  * and false otherwise.
  * <p>

--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Control.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Control.d
@@ -77,7 +77,7 @@ version(Tango){
  * IMPORTANT: This class is intended to be subclassed <em>only</em>
  * within the SWT implementation.
  * </p>
- * 
+ *
  * @see <a href="http://www.eclipse.org/swt/snippets/#control">Control snippets</a>
  * @see <a href="http://www.eclipse.org/swt/examples.php">SWT Example: ControlExample</a>
  * @see <a href="http://www.eclipse.org/swt/">Sample code and further information</a>
@@ -4771,6 +4771,14 @@ LRESULT wmNotifyChild (NMHDR* hdr, WPARAM wParam, LPARAM lParam) {
 
 LRESULT wmScrollChild (WPARAM wParam, LPARAM lParam) {
     return null;
+}
+
+// DWT Custom
+
+// D doesn't support "default" in interfaces
+// originally in org.eclipse.swt.graphics.Drawable
+public bool isAutoScalable () {
+    return true;
 }
 
 }


### PR DESCRIPTION
Updates the `Drawable` interface to match what SWT 4.7.3 has.

SWT uses the `default` keyword so implement a default function body. As D doesn't have an equivalent, I just implemented the default function body in any class which directly implements the `Drawable` interface.

The `Printer` class has a non-default function body, which has been used.