### PR TITLE
Run CI on pull requests for branch 4.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+      - '4.7'
   schedule:
     - cron: '0 0 * * *'
 


### PR DESCRIPTION
Small change to have to CI run when pull requests target the `4.7` branch.

I have this targeting the `4.7` branch since, [according to the docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#example-using-multiple-events-with-activity-types-or-configuration):

> The following steps occur to trigger a workflow run:
> [...]
> 2. The `.github/workflows` directory in your repository is searched for workflow files at the associated commit SHA or Git ref. The workflow files must be present in that commit SHA or Git ref to be considered.
>
> For example, if the event occurred on a particular repository branch, then the workflow files must be present in the repository on that branch.

If you want it to target the `master` branch, just let me know.