### PR TITLE
Error when trying to enter a 32-bit Emoji in a Text control that listen VerifyEvent.

### DIFF
--- a/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
+++ b/org.eclipse.swt.win32.win32.x86/src/org/eclipse/swt/widgets/Text.d
@@ -33,7 +33,7 @@ import org.eclipse.swt.widgets.Control;
 
 import java.lang.all;
 
-import std.conv;
+import std.utf;
 
 /**
  * Instances of this class are selectable user interface
@@ -1485,7 +1485,7 @@ override bool sendKeyEvent (int type, int msg, WPARAM wParam, LPARAM lParam, Eve
             break;
         default:    /* Tab and other characters */
             if (key !is '\t' && key < 0x20) return true;
-            oldText = .to!string(key);
+            oldText = .toUTF8([key]);
             break;
     }
     String newText = verifyText (oldText, start, end, event);


### PR DESCRIPTION
Error "surrogate UTF-16 high value past end of string" when trying to enter a 32-bit Emoji in a Text control that listen VerifyEvent.
For Windows' convenience, processing is done in units of wchar, so dchar will be split into two incomplete wchars when processing VerifyEvent. Using to!string for incomplete characters will result in an error.