### PR TITLE
java.nonstandard.UtfBase: Use forward slashes in #line sequence

### DIFF
--- a/base/src/java/nonstandard/UtfBase.d
+++ b/base/src/java/nonstandard/UtfBase.d
@@ -8,7 +8,7 @@
 module java.nonstandard.UtfBase;
 
 package const UtfBaseText = `
-# line 11 "java\nonstandard\UtfBase.d"
+# line 11 "java/nonstandard/UtfBase.d"
 import java.lang.util;
 
 version(Tango){


### PR DESCRIPTION
Soon, backslashes will need escaping in the file spec of `#line` directives.