### PR TITLE
Update which libraries the snippets link to on Linux

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,10 +21,9 @@ Current supported platforms are Windows, using Win32 and Linux, using GTK.
           "fontconfig" \
           "gdk-x11-2.0" \
           "gdk_pixbuf-2.0" \
+          "gio-2.0" \
           "glib-2.0" \
           "gmodule-2.0" \
-          "gnomeui-2" \
-          "gnomevfs-2" \
           "gobject-2.0" \
           "gthread-2.0" \
           "gtk-x11-2.0" \
@@ -89,7 +88,6 @@ packages available in the system package manager.
 
 * libcairo2-dev
 * libglib2.0-dev
-* libgnomeui-dev
 * libgtk2.0-dev
 * libpango1.0-dev
 * libxcomposite-dev

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet107.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet107.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet108.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet108.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet109.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet109.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet111.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet111.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet115.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet115.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet118.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet118.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet119.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet119.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet122.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet122.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet127.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet127.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet128.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet128.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130a.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet130a.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet132.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet132.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet133.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet133.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet134.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet134.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet136.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet136.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet138.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet138.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet14.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet14.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet140.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet140.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet142.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet142.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet143.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet143.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet144.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet144.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet146.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet146.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet147.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet147.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet15.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet15.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet150.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet150.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet152.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet152.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet153.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet153.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet16.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet16.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet162.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet162.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet163.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet163.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet165.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet165.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet169.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet169.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet170.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet170.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet174.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet174.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet184.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet184.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet189.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet189.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet190.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet190.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet193.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet193.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet195.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet195.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet20.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet20.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet206.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet206.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet207.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet207.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet208.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet208.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet21.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet21.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet211.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet211.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet212.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet212.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet213.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet213.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet214.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet214.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet215.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet215.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet217.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet217.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet218.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet218.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet220.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet220.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet222.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet222.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet223.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet223.d
@@ -11,10 +11,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet224.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet224.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet226.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet226.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet235.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet235.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet237.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet237.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet24.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet24.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet242.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet242.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet244.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet244.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet245.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet245.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet247.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet247.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet25.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet25.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet250.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet250.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet251.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet251.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet258.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet258.d
@@ -11,10 +11,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet26.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet26.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet268.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet268.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet269.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet269.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet275.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet275.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet276.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet276.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet282.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet282.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet286.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet286.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet288.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet288.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet289.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet289.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet29.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet29.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet290.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet290.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet293.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet293.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet294.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet294.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet32.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet32.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet33.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet33.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet38.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet38.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet39.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet39.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet41.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet41.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet42.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet42.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet43.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet43.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet44.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet44.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet45.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet45.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet46.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet46.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet47.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet47.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet48.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet48.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet49.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet49.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet58.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet58.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet60.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet60.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet62.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet62.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet66.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet66.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet67.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet67.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet68.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet68.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet72.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet72.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet74.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet74.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet75.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet75.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet76.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet76.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet81.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet81.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet82.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet82.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet92.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet92.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet94.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet94.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet96.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet96.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet97.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet97.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet98.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/Snippet98.d
@@ -10,10 +10,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetDwtBitmapV4.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetDwtBitmapV4.d
@@ -11,10 +11,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetJPEGImage.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetJPEGImage.d
@@ -11,10 +11,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetManyWidget.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetManyWidget.d
@@ -11,10 +11,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \

--- a/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetPaintItem.d
+++ b/org.eclipse.swt.snippets/src/org/eclipse/swt/snippets/SnippetPaintItem.d
@@ -11,10 +11,9 @@ dub.sdl:
       "fontconfig" \
       "gdk-x11-2.0" \
       "gdk_pixbuf-2.0" \
+      "gio-2.0" \
       "glib-2.0" \
       "gmodule-2.0" \
-      "gnomeui-2" \
-      "gnomevfs-2" \
       "gobject-2.0" \
       "gthread-2.0" \
       "gtk-x11-2.0" \


### PR DESCRIPTION
gnomeui-2 and gnomevfs-2 are outdated and hard to find, replaced with gio-2.0.