### PR TITLE
Apply default locale of "en_US" for Posix

### DIFF
--- a/base/src/java/nonstandard/Locale.d
+++ b/base/src/java/nonstandard/Locale.d
@@ -81,29 +81,25 @@ version(Tango){
 }
 /// Get a omitted calture name. for example: "en-US"
 String caltureName() {
-    version(Tango){
-        return Culture.current.name;
-    } else { // Phobos
-        version (Windows) {
-            if (W_VERSION) {
-                return caltureNameImpl!(wchar, GetLocaleInfoW)();
-            } else {
-                return caltureNameImpl!(char, GetLocaleInfoA)();
-            }
-        } else version (Posix) {
-            // LC_ALL is override to settings of all category.
-            // This is undefined in almost case.
-            String res = .environment.get("LC_ALL", "");
-            if (!res || !res.length) {
-                // LANG is basic Locale setting.
-                // A settings of each category override this. 
-                res = .environment.get("LANG", "");
-            }
-            ptrdiff_t dot = .indexOf(res, '.');
-            if (dot != -1) res = res[0 .. dot];
-            return .replace(res, "_", "-");
+    version (Windows) {
+        if (W_VERSION) {
+            return caltureNameImpl!(wchar, GetLocaleInfoW)();
         } else {
-            static assert(0);
+            return caltureNameImpl!(char, GetLocaleInfoA)();
         }
+    } else version (Posix) {
+        // LC_ALL is override to settings of all category.
+        // This is undefined in almost case.
+        String res = .environment.get("LC_ALL", "");
+        if (!res || !res.length) {
+            // LANG is basic Locale setting.
+            // A settings of each category override this.
+            res = .environment.get("LANG", "en_US");
+        }
+        ptrdiff_t dot = .indexOf(res, '.');
+        if (dot != -1) res = res[0 .. dot];
+        return .replace(res, "_", "-");
+    } else {
+        static assert(0, "Unsupported platform (locale)");
     }
 }


### PR DESCRIPTION
This fixes cases where the LC_ALL *and* LANG environment variables aren't defined, such as the CI.

Having no fallback means [`ResourceBundle.this`][1] will throw an `ArraySliceError` as it expects [`caltureName`][2] to return something.

I was updating SWT.d when the CI failed on Ubuntu ([CI Run][3]) while it still worked fine on Windows ([CI Run][4]).

[1]: https://github.com/d-widget-toolkit/dwt/blob/9233bcd/base/src/java/util/ResourceBundle.d#L28-L40
[2]: https://github.com/d-widget-toolkit/dwt/blob/9233bcd/base/src/java/nonstandard/Locale.d#L96-L100
[3]: https://github.com/summer-alice/dwt/actions/runs/5981467663/job/16231274641
[4]: https://github.com/summer-alice/dwt/actions/runs/5981467663/job/16231274938