### PR TITLE
[Linux] Fix crash when LANG is empty, C, or POSIX

### DIFF
--- a/base/src/java/nonstandard/Locale.d
+++ b/base/src/java/nonstandard/Locale.d
@@ -9,76 +9,77 @@ module java.nonstandard.Locale;
 import java.lang.String;
 import java.lang.util : implMissing;
 
-version(Tango){
-    private import tango.text.locale.Core;
-} else { // Phobos
-    private import std.conv;
-    private import std.exception;
+import core.stdc.string;
 
-    version (Windows) {
-        private import core.stdc.string;
-        private import core.sys.windows.windows;
-        private bool W_VERSION;
-        static this() {
-            W_VERSION = GetVersion < 0x80000000;
+version (Windows) {
+    import core.sys.windows.windows;
+    import std.conv;
+    import std.exception;
+} else version (Posix) {
+    import core.stdc.locale;
+} else {
+    static assert(0, "unsupported platform (locale)");
+}
+
+version (Windows) {
+    private bool W_VERSION;
+    static this() {
+        W_VERSION = GetVersion < 0x80000000;
+    }
+    private extern (Windows) {
+        enum LCID : DWORD {
+            /// The default locale for the user or process.
+            LOCALE_USER_DEFAULT     = 0x0400,
         }
-        private extern (Windows) {
-            enum LCID : DWORD {
-                /// The default locale for the user or process.
-                LOCALE_USER_DEFAULT     = 0x0400,
-            }
-            enum LCTYPE : DWORD {
-                /// ISO639 language name.
-                LOCALE_SISO639LANGNAME  = 0x0059,
-                /// ISO3166 country name.
-                LOCALE_SISO3166CTRYNAME = 0x005A
-            }
-            /// Retrieves information about a locale specified by identifier.
-            /// See_Also: GetLocaleInfo Function (Windows)
-            ///           (http://msdn.microsoft.com/en-us/library/dd318101%28VS.85%29.aspx)
-            INT GetLocaleInfoW(
-                LCID Locale,
-                LCTYPE LCType,
-                LPWSTR lpLCData,
-                INT cchData
-            );
-            /// ditto
-            INT GetLocaleInfoA(
-                LCID Locale,
-                LCTYPE LCType,
-                LPCSTR lpLCData,
-                INT cchData
-            );
+        enum LCTYPE : DWORD {
+            /// ISO639 language name.
+            LOCALE_SISO639LANGNAME  = 0x0059,
+            /// ISO3166 country name.
+            LOCALE_SISO3166CTRYNAME = 0x005A
         }
-        /// A purpose of this templete is switch of W or A in Windows.
-        private String caltureNameImpl(Char, alias GetLocalInfo)() {
-            INT len;
-            Char[] res;
-            Char[] buf;
-            len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
-                LCTYPE.LOCALE_SISO639LANGNAME, null, 0);
-            enforce(len, new Exception("LOCALE_SISO639LANGNAME (len)", __FILE__, __LINE__));
-            buf.length = len;
-            len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
-                LCTYPE.LOCALE_SISO639LANGNAME, buf.ptr, cast(INT)buf.length);
-            enforce(len, new Exception("LOCALE_SISO639LANGNAME", __FILE__, __LINE__));
-            res ~= buf[0 .. len - 1];
-            res ~= '-';
-            len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
-                LCTYPE.LOCALE_SISO3166CTRYNAME, null, 0);
-            enforce(len, new Exception("LOCALE_SISO3166CTRYNAME (len)", __FILE__, __LINE__));
-            buf.length = len;
-            len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
-                LCTYPE.LOCALE_SISO3166CTRYNAME, buf.ptr, cast(INT)buf.length);
-            enforce(len, new Exception("LOCALE_SISO3166CTRYNAME", __FILE__, __LINE__));
-            res ~= buf[0 .. len - 1];
-            return to!(String)(res);
-        }
-    } else version (Posix) {
-        private import std.process : environment;
-        private import std.string : indexOf, replace;
+        /// Retrieves information about a locale specified by identifier.
+        /// See_Also: GetLocaleInfo Function (Windows)
+        ///           (http://msdn.microsoft.com/en-us/library/dd318101%28VS.85%29.aspx)
+        INT GetLocaleInfoW(
+            LCID Locale,
+            LCTYPE LCType,
+            LPWSTR lpLCData,
+            INT cchData
+        );
+        /// ditto
+        INT GetLocaleInfoA(
+            LCID Locale,
+            LCTYPE LCType,
+            LPCSTR lpLCData,
+            INT cchData
+        );
+    }
+    /// A purpose of this templete is switch of W or A in Windows.
+    private String caltureNameImpl(Char, alias GetLocalInfo)() {
+        INT len;
+        Char[] res;
+        Char[] buf;
+        len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
+            LCTYPE.LOCALE_SISO639LANGNAME, null, 0);
+        enforce(len, new Exception("LOCALE_SISO639LANGNAME (len)", __FILE__, __LINE__));
+        buf.length = len;
+        len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
+            LCTYPE.LOCALE_SISO639LANGNAME, buf.ptr, cast(INT)buf.length);
+        enforce(len, new Exception("LOCALE_SISO639LANGNAME", __FILE__, __LINE__));
+        res ~= buf[0 .. len - 1];
+        res ~= '-';
+        len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
+            LCTYPE.LOCALE_SISO3166CTRYNAME, null, 0);
+        enforce(len, new Exception("LOCALE_SISO3166CTRYNAME (len)", __FILE__, __LINE__));
+        buf.length = len;
+        len = GetLocalInfo(LCID.LOCALE_USER_DEFAULT,
+            LCTYPE.LOCALE_SISO3166CTRYNAME, buf.ptr, cast(INT)buf.length);
+        enforce(len, new Exception("LOCALE_SISO3166CTRYNAME", __FILE__, __LINE__));
+        res ~= buf[0 .. len - 1];
+        return to!(String)(res);
     }
 }
+
 /// Get a omitted calture name. for example: "en-US"
 String caltureName() {
     version (Windows) {
@@ -88,18 +89,18 @@ String caltureName() {
             return caltureNameImpl!(char, GetLocaleInfoA)();
         }
     } else version (Posix) {
-        // LC_ALL is override to settings of all category.
-        // This is undefined in almost case.
-        String res = .environment.get("LC_ALL", "");
-        if (!res || !res.length) {
-            // LANG is basic Locale setting.
-            // A settings of each category override this.
-            res = .environment.get("LANG", "en_US");
+        // Sets all categories of the locale for the process.
+        setlocale(LC_ALL, "");
+
+        char* loc = setlocale(LC_MESSAGES, null);
+
+        // C and POSIX aren't valid locales for Java, so fallback to en_US.
+        // https://www.oracle.com/java/technologies/javase/jdk8-jre8-suported-locales.html
+        if (null is loc || (0 == strcmp(loc, "C")) || (0 == strcmp(loc, "POSIX"))) {
+            return "en_US";
         }
-        ptrdiff_t dot = .indexOf(res, '.');
-        if (dot != -1) res = res[0 .. dot];
-        return .replace(res, "_", "-");
-    } else {
-        static assert(0, "Unsupported platform (locale)");
+
+        size_t len = strlen(loc);
+        return loc[0..len].dup;
     }
 }

--- a/base/src/java/nonstandard/Locale.d
+++ b/base/src/java/nonstandard/Locale.d
@@ -104,3 +104,43 @@ String caltureName() {
         return loc[0..len].dup;
     }
 }
+
+
+
+version (Posix)
+{
+    // Check that an empty LC_ALL and LANG still will default
+    // to en_US.
+    //
+    // See: https://github.com/d-widget-toolkit/dwt/pull/115
+    //      https://github.com/d-widget-toolkit/dwt/pull/117
+    unittest
+    {
+        import std.process : environment;
+        import java.lang.util : Format;
+
+        immutable lc_all = environment.get("LC_ALL", null);
+        immutable lang = environment.get("LANG", null);
+        immutable locale = caltureName();
+
+        scope(exit)
+        {
+            environment["LC_ALL"] = lc_all;
+            environment["LANG"] = lang;
+        }
+
+        environment.remove("LC_ALL");
+        environment.remove("LANG");
+
+        if (null !is lc_all) {
+            assert(
+                lc_all == locale,
+                Format("caltureName {} does not equal LC_ALL {}", locale, lc_all));
+        }
+
+        assert(
+            "en_US" == caltureName(),
+            Format("Failed to set default locale of en_US (got {})", locale));
+    }
+}
+

--- a/base/src/java/util/ResourceBundle.d
+++ b/base/src/java/util/ResourceBundle.d
@@ -9,12 +9,8 @@ import java.lang.exceptions;
 import java.util.MissingResourceException;
 import java.util.Enumeration;
 import java.nonstandard.Locale;
-version(Tango){
-    //import tango.text.Util;
-    import tango.io.device.File;
-} else { // Phobos
-    static import std.file;
-}
+
+static import std.file;
 
 
 class ResourceBundle {
@@ -37,12 +33,14 @@ class ResourceBundle {
                 }
             }
         }
-        char[] end = "_" ~ name[0..2] ~ ".properties";
-        foreach( entry; data ){
-            if( entry.name.length > end.length && entry.name[ $-end.length .. $ ] == end ){
-                //Trace.formatln( "ResourceBundle {}", entry.name );
-                initialize( cast(String)entry.data );
-                return;
+        if (name.length >= 2) {
+            char[] end = "_" ~ name[0..2] ~ ".properties";
+            foreach(entry; data) {
+                if (entry.name.length > end.length && entry.name[$-end.length..$] == end) {
+                    //Trace.formatln( "ResourceBundle {}", entry.name ):
+                    initialize(cast(String)entry.data);
+                    return;
+                }
             }
         }
         //Trace.formatln( "ResourceBundle default" );

--- a/tests/SWT.d
+++ b/tests/SWT.d
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2000, 2015 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *     Red Hat Inc. - Bug 462631
+ *******************************************************************************/
+module tests.SWT;
+
+import std.exception : assertThrown, assertNotThrown;
+
+import java.lang.exceptions;
+
+import org.eclipse.swt.all : SWT, SWTException, SWTError;
+
+@("test_Constructor")
+unittest
+{
+    // Do nothing. Class SWT is not intended to be subclassed.
+}
+
+@("test_errorI")
+unittest {
+    // Test that we throw the expected kinds of errors for the given error types.
+
+    assertThrown!IllegalArgumentException(SWT.error(SWT.ERROR_NULL_ARGUMENT),
+        "Did not correctly throw exception for ERROR_NULL_ARGUMENT");
+
+    assertThrown!SWTException(SWT.error(SWT.ERROR_FAILED_EXEC),
+        "Did not correctly throw exception ERROR_FAILED_EXEC");
+
+    assertThrown!SWTError(SWT.error(SWT.ERROR_NO_HANDLES),
+        "Did not correctly throw exception ERROR_NO_HANDLES");
+
+    assertThrown!SWTError(SWT.error(-1),
+        "Did not correctly throw exception for error(-1)");
+}
+
+@("test_errorILjava_lang_Throwable")
+unittest
+{
+    // Test that the causing throwable is filled in.
+    Exception cause = new RuntimeException("Just for testing");
+    bool passed = false;
+
+    try {
+        SWT.error(SWT.ERROR_UNSUPPORTED_FORMAT, cause);
+    } catch (SWTException ex) {
+        passed = ex.throwable == cause;
+    } catch (Exception e) { }
+    assert(passed, "Did not correctly throw exception for ERROR_UNSUPPORTE_FORMAT");
+
+    passed = false;
+    try {
+        SWT.error(SWT.ERROR_NOT_IMPLEMENTED, cause);
+    } catch (SWTError ex) {
+        passed = ex.throwable == cause;
+    } catch (Exception e) { }
+    assert(passed, "Did not correctly throw exception for ERROR_NOT_IMPLEMENTED");
+
+    passed = false;
+    try {
+        SWT.error(-1, cause);
+    } catch (SWTError ex) {
+        passed = ex.throwable == cause;
+    } catch (Exception e) { }
+    assert(passed, "Did not correctly throw exception for error(-1)");
+}
+
+@("test_getMessageLjava_lang_String")
+unittest
+{
+    assertThrown!IllegalArgumentException(SWT.getMessage(null),
+        "Did not correctly throw exception with null argument");
+
+    assertNotThrown!Exception(SWT.getMessage("SWT_Yes"),
+        "Exception generated for SWT_Yes");
+
+    assert(SWT.getMessage("_NOT_FOUND_IN_PROPERTIES_") == "_NOT_FOUND_IN_PROPERTIES_",
+        "Invalid key did not return as itself");
+}
+
+@("test_getPlatform")
+unittest
+{
+    // Can't test the list of platforms, since this may change,
+    // so just test to see it returns something.
+    assert(SWT.getPlatform() !is null, "Returned null platform name");
+}
+
+@("test_getVersion")
+unittest
+{
+    import std.stdio : writeln;
+
+    // Test that the version number which is returned is reasonable.
+    int ver = SWT.getVersion();
+    assert(ver > 0 && ver < 1_000_000, "Unreasonable value returned");
+    writeln("SWT.getVersion(): ", ver);
+}


### PR DESCRIPTION
So my [last attempt] didn't actually fix it. I thought I tested it, but apparently not... my bad.

I've changed the `caltureName` implementation for `version(Posix)` to use the [`setlocale`], which will check all applicable  environment variables for us.

I also changed `ResourceBundle.this(in ImportData[])` to check if the string has enough characters before attempting a splice.

You can check this works with the [a CI run from my `update-swt-4.7` branch][lci] (which had been [failing] because of this issue) after I'd pushed these changes.

[last attempt]: https://github.com/d-widget-toolkit/dwt/pull/115
[`setlocale`]: https://www.man7.org/linux/man-pages/man3/setlocale.3.html
[lci]: https://github.com/summer-alice/dwt/actions/runs/6036656687
[failing]: https://github.com/summer-alice/dwt/actions/runs/6035161590