### PR TITLE
Drop support for Tango in java.io

### DIFF
--- a/base/src/java/io/ByteArrayOutputStream.d
+++ b/base/src/java/io/ByteArrayOutputStream.d
@@ -6,65 +6,35 @@ module java.io.ByteArrayOutputStream;
 public import java.io.OutputStream;
 import java.lang.all;
 
-version(Tango){
-    import tango.io.device.Array;
-} else { // Phobos
-    import std.outbuffer;
-}
+import std.outbuffer;
 
 public class ByteArrayOutputStream : java.io.OutputStream.OutputStream {
-
-    version(Tango){
-        protected Array buffer;
-    } else { // Phobos
-        protected OutBuffer buffer;
-    }
+    protected OutBuffer buffer;
 
     public this (){
-        version(Tango){
-            buffer = new Array(0, 1);
-        } else { // Phobos
-            buffer = new OutBuffer();
-        }
+        buffer = new OutBuffer();
     }
 
     public this ( int par_size ){
-        version(Tango){
-            buffer = new Array(par_size, 1);
-        } else { // Phobos
-            buffer = new OutBuffer();
-            buffer.reserve(par_size);
-        }
+        buffer = new OutBuffer();
+        buffer.reserve(par_size);
     }
 
     public override void write( int b ){
         synchronized {
-            version(Tango){
-                byte[1] a = b & 0xFF;
-                buffer.append(a);
-            } else { // Phobos
-                buffer.write(cast(ubyte)(b & 0xFF));
-            }
+            buffer.write(cast(ubyte)(b & 0xFF));
         }
     }
 
     public override void write( in byte[] b, ptrdiff_t off, ptrdiff_t len ){
         synchronized {
-            version(Tango){
-                buffer.append( b[ off .. off + len ] );
-            } else { // Phobos
-                buffer.write( cast(ubyte[]) b[ off .. off + len ]);
-            }
+            buffer.write( cast(ubyte[]) b[ off .. off + len ]);
         }
     }
 
     public override void write( in byte[] b ){
         synchronized {
-            version(Tango){
-                buffer.append( b );
-            } else { // Phobos
-                buffer.write( cast(ubyte[]) b );
-            }
+            buffer.write( cast(ubyte[]) b );
         }
     }
 
@@ -80,11 +50,7 @@ public class ByteArrayOutputStream : java.io.OutputStream.OutputStream {
 
     public byte[] toByteArray(){
         synchronized {
-            version(Tango){
-                return cast(byte[]) buffer.slice();
-            } else { // Phobos
-                return cast(byte[]) buffer.toBytes();
-            }
+            return cast(byte[]) buffer.toBytes();
         }
     }
 

--- a/base/src/java/io/File.d
+++ b/base/src/java/io/File.d
@@ -5,22 +5,12 @@ module java.io.File;
 
 import java.lang.all;
 
-version(Tango){
-    static import tango.io.model.IFile;
-    static import tango.io.FilePath;
-    static import tango.io.Path;
-    static import tango.io.FileSystem;
-    static import tango.sys.Environment;
-    static import tango.sys.Common;
-    static import tango.stdc.stringz; //for toStringz
-    version(Posix) static import tango.stdc.posix.unistd; //for access
-} else { // Phobos
-    static import std.file;
-    static import std.path;
-    static import std.string; //for toStringz
-    version(Posix) static import core.sys.posix.unistd; //for access
-}
-// Implement this more efficient by using FilePath in Tango 
+
+static import std.file;
+static import std.path;
+static import std.string; //for toStringz
+version(Posix) static import core.sys.posix.unistd; //for access
+
 public class File {
 
     public static char separatorChar;
@@ -31,32 +21,17 @@ public class File {
     private String mFilePath;
 
     static this(){
-        version(Tango){
-            separator = tango.io.model.IFile.FileConst.PathSeparatorString;
-            separatorChar = tango.io.model.IFile.FileConst.PathSeparatorChar;
-            pathSeparator = tango.io.model.IFile.FileConst.SystemPathString;
-            pathSeparatorChar = tango.io.model.IFile.FileConst.SystemPathChar;
-        } else { // Phobos
-            separator = std.path.dirSeparator;
-            separatorChar = std.path.dirSeparator[0];
-            pathSeparator = std.path.pathSeparator;
-            pathSeparatorChar = std.path.pathSeparator[0];
-        }
+        separator = std.path.dirSeparator;
+        separatorChar = std.path.dirSeparator[0];
+        pathSeparator = std.path.pathSeparator;
+        pathSeparatorChar = std.path.pathSeparator[0];
     }
 
     private static String toStd( String path ){
-        version(Tango){
-            return tango.io.Path.standard( path.dup );
-        } else { // Phobos
-            return path;
-        }
+        return path;
     }
     private static String join( String path, String file ){
-        version(Tango){
-            return tango.io.Path.join( toStd(path), toStd(file) );
-        } else { // Phobos
-            return std.path.buildPath( toStd(path), toStd(file) );
-        }
+        return std.path.buildPath( toStd(path), toStd(file) );
     }
 
     public this ( String pathname ){
@@ -68,11 +43,7 @@ public class File {
     }
 
     public this ( java.io.File.File parent, String child ){
-        version(Tango){
-            mFilePath = tango.io.Path.join( parent.mFilePath, toStd(child) );
-        } else { // Phobos
-            mFilePath = std.path.buildPath( parent.mFilePath, toStd(child) );
-        }
+        mFilePath = std.path.buildPath( parent.mFilePath, toStd(child) );
     }
 
     public int getPrefixLength(){
@@ -106,11 +77,7 @@ public class File {
     }
 
     public String getAbsolutePath(){
-        version(Tango){
-            return (new tango.io.FilePath.FilePath(mFilePath)).absolute(tango.sys.Environment.Environment.cwd).toString;
-        } else { // Phobos
-            return std.path.absolutePath(mFilePath);
-        }
+        return std.path.absolutePath(mFilePath);
     }
 
     public java.io.File.File getAbsoluteFile(){
@@ -134,35 +101,19 @@ public class File {
 
     public bool canWrite(){
         version(Windows) { //Windows's ACL isn't supported
-            version(Tango) {
-                return tango.io.Path.isWritable(mFilePath);
-            } else { // Phobos
-                return !(std.file.getAttributes(mFilePath) & 1); //FILE_ATTRIBUTE_READONLY = 1
-            }
-        } else version(Posix) { //workaround Tango's bug (isWritable is always true)
-            version(Tango) {
-                return tango.stdc.posix.unistd.access (tango.stdc.stringz.toStringz(mFilePath), 2) is 0; //W_OK = 2
-            } else { // Phobos
-                return core.sys.posix.unistd.access (std.string.toStringz(mFilePath), 2) is 0; //W_OK = 2
-            }
+            return !(std.file.getAttributes(mFilePath) & 1); //FILE_ATTRIBUTE_READONLY = 1
+        } else version(Posix) {
+            return core.sys.posix.unistd.access (std.string.toStringz(mFilePath), 2) is 0; //W_OK = 2
         } else
             static assert(0);
     }
 
     public bool exists(){
-        version(Tango){
-            return tango.io.Path.exists(mFilePath);
-        } else { // Phobos
-            return std.file.exists(mFilePath);
-        }
+        return std.file.exists(mFilePath);
     }
 
     public bool isDirectory(){
-        version(Tango){
-            return tango.io.Path.isFolder(mFilePath);
-        } else { // Phobos
-            return std.file.isDir(mFilePath);
-        }
+        return std.file.isDir(mFilePath);
     }
 
     public bool isFile(){

--- a/base/src/java/io/FileInputStream.d
+++ b/base/src/java/io/FileInputStream.d
@@ -7,21 +7,14 @@ import java.lang.all;
 import java.io.File;
 import java.io.InputStream;
 
-version(Tango){
-    import TangoFile = tango.io.device.File;
-} else { // Phobos
-    static import std.stdio;
-}
+static import std.stdio;
 
 public class FileInputStream : java.io.InputStream.InputStream {
 
     alias java.io.InputStream.InputStream.read read;
 
-    version(Tango){
-        private TangoFile.File conduit;
-    } else { // Phobos
-        private std.stdio.File conduit;
-    }
+    private std.stdio.File conduit;
+
     private ubyte[] buffer;
     private int buf_pos;
     private int buf_size;
@@ -29,71 +22,38 @@ public class FileInputStream : java.io.InputStream.InputStream {
     private bool eof;
 
     public this ( String name ){
-        version(Tango){
-            conduit = new TangoFile.File( name );
-        } else { // Phobos
-            conduit = std.stdio.File( name, "rb" );
-        }
+        conduit = std.stdio.File( name, "rb" );
         buffer = new ubyte[]( BUFFER_SIZE );
     }
 
     public this ( java.io.File.File file ){
         implMissing( __FILE__, __LINE__ );
-        version(Tango){
-            conduit = new TangoFile.File( file.getAbsolutePath(), TangoFile.File.ReadExisting );
-        } else { // Phobos
-            conduit = std.stdio.File( file.getAbsolutePath(), "rb" );
-        }
+        conduit = std.stdio.File( file.getAbsolutePath(), "rb" );
         buffer = new ubyte[]( BUFFER_SIZE );
     }
 
     public override int read(){
-        version(Tango){
-            if( eof ){
-                return -1;
+        if( eof ){
+            return -1;
+        }
+        try{
+            if( buf_pos == buf_size ){
+                buf_pos = 0;
+                buf_size = cast(int)/*64bit*/conduit.rawRead( buffer ).length;
             }
-            try{
-                if( buf_pos == buf_size ){
-                    buf_pos = 0;
-                    buf_size = conduit.input.read( buffer );
-                }
-                if( buf_size <= 0 ){
-                    eof = true;
-                    return -1;
-                }
-                assert( buf_pos < BUFFER_SIZE, Format( "{0} {1}", buf_pos, buf_size ) );
-                assert( buf_size <= BUFFER_SIZE );
-                int res = cast(int) buffer[ buf_pos ];
-                buf_pos++;
-                return res;
-            }
-            catch( IOException e ){
+            if( buf_size <= 0 ){
                 eof = true;
                 return -1;
             }
-        } else { // Phobos
-            if( eof ){
-                return -1;
-            }
-            try{
-                if( buf_pos == buf_size ){
-                    buf_pos = 0;
-                    buf_size = cast(int)/*64bit*/conduit.rawRead( buffer ).length;
-                }
-                if( buf_size <= 0 ){
-                    eof = true;
-                    return -1;
-                }
-                assert( buf_pos < BUFFER_SIZE, Format( "{} {}", buf_pos, buf_size ) );
-                assert( buf_size <= BUFFER_SIZE );
-                int res = cast(int) buffer[ buf_pos ];
-                buf_pos++;
-                return res;
-            }
-            catch( IOException e ){
-                eof = true;
-                return -1;
-            }
+            assert( buf_pos < BUFFER_SIZE, Format( "{} {}", buf_pos, buf_size ) );
+            assert( buf_size <= BUFFER_SIZE );
+            int res = cast(int) buffer[ buf_pos ];
+            buf_pos++;
+            return res;
+        }
+        catch( IOException e ){
+            eof = true;
+            return -1;
         }
     }
 

--- a/base/src/java/io/FileOutputStream.d
+++ b/base/src/java/io/FileOutputStream.d
@@ -8,36 +8,20 @@ public import java.io.OutputStream;
 
 import java.lang.all;
 
-version(Tango){
-    import TangoFile = tango.io.device.File;
-} else { // Phobos
-    static import std.stdio;
-}
+static import std.stdio;
 
 public class FileOutputStream : java.io.OutputStream.OutputStream {
 
     alias java.io.OutputStream.OutputStream.write write;
     alias java.io.OutputStream.OutputStream.close close;
-    version(Tango){
-        private TangoFile.File fc;
-    } else { // Phobos
-        private std.stdio.File fc;
-    }
+    private std.stdio.File fc;
 
     public this ( String name ){
-        version(Tango){
-            fc = new TangoFile.File( name, TangoFile.File.WriteCreate );
-        } else { // Phobos
-            fc = std.stdio.File( name, "wb" );
-        }
+        fc = std.stdio.File( name, "wb" );
     }
 
     public this ( String name, bool append ){
-        version(Tango){
-            fc = new TangoFile.File( name, append ? TangoFile.File.WriteAppending : TangoFile.File.WriteCreate );
-        } else { // Phobos
-            fc = std.stdio.File( name, append ? "ab" : "wb" );
-        }
+        fc = std.stdio.File( name, append ? "ab" : "wb" );
     }
 
     public this ( java.io.File.File file ){
@@ -50,11 +34,7 @@ public class FileOutputStream : java.io.OutputStream.OutputStream {
 
     public override void write( int b ){
         ubyte[1] a = b & 0xFF;
-        version(Tango){
-            fc.write(a);
-        } else { // Phobos
-            fc.rawWrite(a);
-        }
+        fc.rawWrite(a);
     }
 
     public override void close(){


### PR DESCRIPTION
Drops support for Tango in `java.io` (ref https://github.com/d-widget-toolkit/dwt/pull/63#issuecomment-765243356)

Instead of dropping support only when changing something in a module resulting in a messier PR.