### PR TITLE
[ci] Update action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
+        uses: actions/checkout@v4
       - name: Install D Compiler ${{ matrix.dc }}
         uses: dlang-community/setup-dlang@v1
         with:
@@ -73,7 +71,7 @@ jobs:
 
       - name: Test DWT Gtk (${{ matrix.buildType }})
         if: ${{ matrix.os == 'ubuntu-20.04' }}
-        uses: GabrielBB/xvfb-action@v1 # X virtual framebuffer
+        uses: coactions/setup-xvfb@v1 # X virtual framebuffer
         with:
           working-directory: ./
           run: dub test -c unittest-gtk -b ${{ matrix.buildType }}


### PR DESCRIPTION
Old versions were using Node 12 which github has stopped supporting (in the background it was forcing them to run on Node 16).

See: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Might also be worth looking at bumping the D compiler versions (we jump from 2.090.1 to "latest"), if you're happy to.